### PR TITLE
Don't use TCy prefix. Make the name same as default thrift.

### DIFF
--- a/thriftpy/protocol/__init__.py
+++ b/thriftpy/protocol/__init__.py
@@ -7,12 +7,14 @@ __all__ = ['TBinaryProtocol', 'TBinaryProtocolFactory',
            'TJSONProtocol', 'TJSONProtocolFactory']
 
 
-from .binary import TBinaryProtocol, TBinaryProtocolFactory
 from .json import TJSONProtocol, TJSONProtocolFactory
 
 from thriftpy._compat import PYPY
-if not PYPY:
-    from .cybin import TCyBinaryProtocol, TCyBinaryProtocolFactory
+if PYPY:
+    from .binary import TBinaryProtocol, TBinaryProtocolFactory
 else:
-    TCyBinaryProtocol = TBinaryProtocol
-    TCyBinaryProtocolFactory = TBinaryProtocolFactory
+    from .cybin import TBinaryProtocol, TBinaryProtocolFactory
+
+# backward compatible
+TCyBinaryProtocol = TBinaryProtocol
+TCyBinaryProtocolFactory = TBinaryProtocolFactory

--- a/thriftpy/protocol/cybin/cybin.pyx
+++ b/thriftpy/protocol/cybin/cybin.pyx
@@ -2,7 +2,7 @@ from libc.stdlib cimport free, malloc
 from libc.stdint cimport int16_t, int32_t, int64_t
 from cpython cimport bool
 
-from thriftpy.transport.cytransport cimport TCyBufferedTransport
+from thriftpy.transport.cytransport cimport TBufferedTransport
 
 cdef extern from "endian_port.h":
     int16_t htobe16(int16_t n)
@@ -43,60 +43,60 @@ class ProtocolError(Exception):
     pass
 
 
-cdef inline char read_i08(TCyBufferedTransport buf) except? -1:
+cdef inline char read_i08(TBufferedTransport buf) except? -1:
     cdef char data
     buf.c_read(1, &data)
     return data
 
 
-cdef inline int16_t read_i16(TCyBufferedTransport buf) except? -1:
+cdef inline int16_t read_i16(TBufferedTransport buf) except? -1:
     cdef char data[2]
     buf.c_read(2, data)
     return be16toh((<int16_t*>data)[0])
 
 
-cdef inline int32_t read_i32(TCyBufferedTransport buf) except? -1:
+cdef inline int32_t read_i32(TBufferedTransport buf) except? -1:
     cdef char data[4]
     buf.c_read(4, data)
     return be32toh((<int32_t*>data)[0])
 
 
-cdef inline int64_t read_i64(TCyBufferedTransport buf) except? -1:
+cdef inline int64_t read_i64(TBufferedTransport buf) except? -1:
     cdef char data[8]
     buf.c_read(8, data)
     return be64toh((<int64_t*>data)[0])
 
 
-cdef inline int write_i08(TCyBufferedTransport buf, char val) except -1:
+cdef inline int write_i08(TBufferedTransport buf, char val) except -1:
     buf.c_write(&val, 1)
     return 0
 
 
-cdef inline int write_i16(TCyBufferedTransport buf, int16_t val) except -1:
+cdef inline int write_i16(TBufferedTransport buf, int16_t val) except -1:
     val = htobe16(val)
     buf.c_write(<char*>(&val), 2)
     return 0
 
 
-cdef inline int write_i32(TCyBufferedTransport buf, int32_t val) except -1:
+cdef inline int write_i32(TBufferedTransport buf, int32_t val) except -1:
     val = htobe32(val)
     buf.c_write(<char*>(&val), 4)
     return 0
 
 
-cdef inline int write_i64(TCyBufferedTransport buf, int64_t val) except -1:
+cdef inline int write_i64(TBufferedTransport buf, int64_t val) except -1:
     val = htobe64(val)
     buf.c_write(<char*>(&val), 8)
     return 0
 
 
-cdef inline int write_double(TCyBufferedTransport buf, double val) except -1:
+cdef inline int write_double(TBufferedTransport buf, double val) except -1:
     cdef int64_t v = htobe64((<int64_t*>(&val))[0])
     buf.c_write(<char*>(&v), 8)
     return 0
 
 
-cdef inline read_struct(TCyBufferedTransport buf, obj):
+cdef inline read_struct(TBufferedTransport buf, obj):
     cdef dict field_specs = obj.thrift_spec
     cdef int fid, i
     cdef TType field_type, orig_field_type, ttype
@@ -129,7 +129,7 @@ cdef inline read_struct(TCyBufferedTransport buf, obj):
     return obj
 
 
-cdef inline write_struct(TCyBufferedTransport buf, obj):
+cdef inline write_struct(TBufferedTransport buf, obj):
     cdef int fid, items_len, i
     cdef TType f_type
     cdef dict thrift_spec = obj.thrift_spec
@@ -155,7 +155,7 @@ cdef inline write_struct(TCyBufferedTransport buf, obj):
     write_i08(buf, T_STOP)
 
 
-cdef inline c_read_string(TCyBufferedTransport buf, int32_t size):
+cdef inline c_read_string(TBufferedTransport buf, int32_t size):
     cdef char string_val[STACK_STRING_LEN]
 
     if size > STACK_STRING_LEN:
@@ -173,7 +173,7 @@ cdef inline c_read_string(TCyBufferedTransport buf, int32_t size):
         return py_data
 
 
-cdef c_read_val(TCyBufferedTransport buf, TType ttype, spec=None):
+cdef c_read_val(TBufferedTransport buf, TType ttype, spec=None):
     cdef int size
     cdef char* data
     cdef bytes py_data
@@ -250,7 +250,7 @@ cdef c_read_val(TCyBufferedTransport buf, TType ttype, spec=None):
         return read_struct(buf, spec())
 
 
-cdef c_write_val(TCyBufferedTransport buf, TType ttype, val, spec=None):
+cdef c_write_val(TBufferedTransport buf, TType ttype, val, spec=None):
     cdef int val_len
     cdef TType e_type, v_type, k_type
 
@@ -327,7 +327,7 @@ cdef c_write_val(TCyBufferedTransport buf, TType ttype, val, spec=None):
         write_struct(buf, val)
 
 
-cpdef skip(TCyBufferedTransport buf, TType ttype):
+cpdef skip(TBufferedTransport buf, TType ttype):
     cdef TType v_type, k_type, f_type
     cdef int i, size
 
@@ -363,16 +363,16 @@ cpdef skip(TCyBufferedTransport buf, TType ttype):
             skip(buf, f_type)
 
 
-def read_val(TCyBufferedTransport buf, TType ttype):
+def read_val(TBufferedTransport buf, TType ttype):
     return c_read_val(buf, ttype)
 
 
-def write_val(TCyBufferedTransport buf, TType ttype, val, spec=None):
+def write_val(TBufferedTransport buf, TType ttype, val, spec=None):
     c_write_val(buf, ttype, val, spec)
 
 
-cdef class TCyBinaryProtocol(object):
-    cdef public TCyBufferedTransport trans
+cdef class TBinaryProtocol(object):
+    cdef public TBufferedTransport trans
     cdef public bool strict_read
     cdef public bool strict_write
 
@@ -428,10 +428,10 @@ cdef class TCyBinaryProtocol(object):
         write_struct(self.trans, obj)
 
 
-class TCyBinaryProtocolFactory(object):
+class TBinaryProtocolFactory(object):
     def __init__(self, strict_read=True, strict_write=True):
         self.strict_read = strict_read
         self.strict_write = strict_write
 
     def get_protocol(self, trans):
-        return TCyBinaryProtocol(trans, self.strict_read, self.strict_write)
+        return TBinaryProtocol(trans, self.strict_read, self.strict_write)

--- a/thriftpy/transport/__init__.py
+++ b/thriftpy/transport/__init__.py
@@ -17,15 +17,16 @@ from .transport import (
     TTransportBase,
     TTransportException,
     TMemoryBuffer,
-    TBufferedTransport,
-    TBufferedTransportFactory,
     TFramedTransport,
     TFramedTransportFactory,
 )
 
 from thriftpy._compat import PYPY
-if not PYPY:
-    from .cytransport import TCyBufferedTransport, TCyBufferedTransportFactory
+if PYPY:
+    from .transport import TBufferedTransport, TBufferedTransportFactory
 else:
-    TCyBufferedTransport = TBufferedTransport
-    TCyBufferedTransportFactory = TBufferedTransportFactory
+    from .cytransport import TBufferedTransport, TBufferedTransportFactory
+
+# backward compatible
+TCyBufferedTransport = TBufferedTransport
+TCyBufferedTransportFactory = TBufferedTransportFactory

--- a/thriftpy/transport/cytransport.pxd
+++ b/thriftpy/transport/cytransport.pxd
@@ -1,4 +1,4 @@
-cdef class TCyBuffer(object):
+cdef class TBuffer(object):
     cdef char *buf
     cdef int cur, buf_size, data_size
 
@@ -7,9 +7,9 @@ cdef class TCyBuffer(object):
     cdef int grow(self, int min_size)
 
 
-cdef class TCyBufferedTransport(object):
+cdef class TBufferedTransport(object):
     cdef object trans
-    cdef TCyBuffer rbuf, wbuf
+    cdef TBuffer rbuf, wbuf
 
     cdef c_read(self, int sz, char* out)
     cdef c_write(self, char* data, int sz)

--- a/thriftpy/transport/cytransport.pyx
+++ b/thriftpy/transport/cytransport.pyx
@@ -5,7 +5,7 @@ DEF DEFAULT_BUFFER = 4096
 DEF MIN_BUFFER_SZIE = 1024
 
 
-cdef class TCyBuffer(object):
+cdef class TBuffer(object):
     def __cinit__(self, buf_size):
         self.buf = <char*>malloc(buf_size)
         self.buf_size = buf_size
@@ -44,7 +44,7 @@ cdef class TCyBuffer(object):
         return 0
 
 
-cdef class TCyBufferedTransport(object):
+cdef class TBufferedTransport(object):
     """binary reader/writer"""
 
     def __init__(self, trans, int buf_size=DEFAULT_BUFFER):
@@ -52,8 +52,8 @@ cdef class TCyBufferedTransport(object):
             raise Exception("buffer too small")
 
         self.trans = trans
-        self.rbuf = TCyBuffer(buf_size)
-        self.wbuf = TCyBuffer(buf_size)
+        self.rbuf = TBuffer(buf_size)
+        self.wbuf = TBuffer(buf_size)
 
     def is_open(self):
         return self.trans.is_open()
@@ -130,6 +130,6 @@ cdef class TCyBufferedTransport(object):
         return self.trans.getvalue()
 
 
-class TCyBufferedTransportFactory(object):
+class TBufferedTransportFactory(object):
     def get_transport(self, trans):
-        return TCyBufferedTransport(trans)
+        return TBufferedTransport(trans)


### PR DESCRIPTION
There is no need for a `TCy` preifx. Cython is used for speeding. Take a look at https://github.com/mitsuhiko/markupsafe/blob/master/markupsafe/__init__.py#L291
