### PR TITLE
Fix issue with receiving 0-length strings & framed transport.

### DIFF
--- a/tests/test_framed_transport.py
+++ b/tests/test_framed_transport.py
@@ -37,6 +37,14 @@ class Dispatcher(object):
         self.registry[person.name] = person
         return True
 
+    def get(self, name):
+        """
+        Person get(1: string name)
+        """
+        if name not in self.registry:
+            raise addressbook.PersonNotExistsError()
+        return self.registry[name]
+
 
 class FramedTransportTestCase(TestCase):
     def mk_server(self):
@@ -75,3 +83,10 @@ class FramedTransportTestCase(TestCase):
         assert success
         success = self.client.add(dennis)
         assert not success
+
+    def test_zero_length_string(self):
+        dennis = addressbook.Person(name='')
+        success = self.client.add(dennis)
+        assert success
+        success = self.client.get(name='')
+        assert success

--- a/thriftpy/transport/transport.py
+++ b/thriftpy/transport/transport.py
@@ -156,6 +156,11 @@ class TFramedTransport(TTransportBase):
         return self.__trans.close()
 
     def read(self, sz):
+        # Important: don't attempt to read the next frame if the caller
+        # doesn't actually need any data.
+        if sz == 0:
+            return b''
+
         ret = self.__rbuf.read(sz)
         if len(ret) != 0:
             return ret


### PR DESCRIPTION
When we request to read 0 bytes we could attempt to read a frame. If we're at the end of the response, this will never return.
