### PR TITLE
Add a mostly cythonized version of the framed transport.

### DIFF
--- a/tests/test_framed_transport.py
+++ b/tests/test_framed_transport.py
@@ -15,7 +15,10 @@ from tornado import ioloop
 import thriftpy
 from thriftpy.tornado import make_server
 from thriftpy.rpc import make_client
-from thriftpy.transport import TFramedTransportFactory
+from thriftpy.transport import (
+    TFramedTransportFactory,
+    TCyFramedTransportFactory,
+)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -47,6 +50,8 @@ class Dispatcher(object):
 
 
 class FramedTransportTestCase(TestCase):
+    TRANSPORT_FACTORY = TFramedTransportFactory()
+
     def mk_server(self):
         self.io_loop = ioloop.IOLoop()
         server = make_server(addressbook.AddressBookService,
@@ -70,7 +75,7 @@ class FramedTransportTestCase(TestCase):
     def mk_client(self):
         return make_client(addressbook.AddressBookService,
                            '127.0.0.1', self.port,
-                           trans_factory=TFramedTransportFactory())
+                           trans_factory=self.TRANSPORT_FACTORY)
 
     def setUp(self):
         self.mk_server()
@@ -90,3 +95,7 @@ class FramedTransportTestCase(TestCase):
         assert success
         success = self.client.get(name='')
         assert success
+
+
+class CyFramedTransportTestCase(FramedTransportTestCase):
+    TRANSPORT_FACTORY = TCyFramedTransportFactory()

--- a/thriftpy/transport/__init__.py
+++ b/thriftpy/transport/__init__.py
@@ -25,7 +25,12 @@ from .transport import (
 
 from thriftpy._compat import PYPY
 if not PYPY:
-    from .cytransport import TCyBufferedTransport, TCyBufferedTransportFactory
+    from .cytransport import (
+        TCyBufferedTransport,
+        TCyBufferedTransportFactory,
+        TCyFramedTransportFactory,
+    )
 else:
     TCyBufferedTransport = TBufferedTransport
     TCyBufferedTransportFactory = TBufferedTransportFactory
+    TCyFramedTransportFactory = TFramedTransportFactory

--- a/thriftpy/transport/cytransport.pyx
+++ b/thriftpy/transport/cytransport.pyx
@@ -1,10 +1,10 @@
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy, memmove
 
-from ..transport import TTransportException
+from ..transport import TFramedTransport, TTransportException
 
 DEF DEFAULT_BUFFER = 4096
-DEF MIN_BUFFER_SZIE = 1024
+DEF MIN_BUFFER_SIZE = 1024
 
 
 cdef class TCyBuffer(object):
@@ -50,7 +50,7 @@ cdef class TCyBufferedTransport(object):
     """binary reader/writer"""
 
     def __init__(self, trans, int buf_size=DEFAULT_BUFFER):
-        if buf_size < MIN_BUFFER_SZIE:
+        if buf_size < MIN_BUFFER_SIZE:
             raise Exception("buffer too small")
 
         self.trans = trans
@@ -136,6 +136,7 @@ cdef class TCyBufferedTransport(object):
         if self.wbuf.data_size > 0:
             data = self.wbuf.buf[:self.wbuf.data_size]
             self.trans.write(data)
+            self.trans.flush()
             self.wbuf.clean()
 
     def getvalue(self):
@@ -145,3 +146,7 @@ cdef class TCyBufferedTransport(object):
 class TCyBufferedTransportFactory(object):
     def get_transport(self, trans):
         return TCyBufferedTransport(trans)
+
+class TCyFramedTransportFactory(object):
+    def get_transport(self, trans):
+        return TCyBufferedTransport(TFramedTransport(trans))

--- a/thriftpy/transport/socket.py
+++ b/thriftpy/transport/socket.py
@@ -106,15 +106,7 @@ class TSocket(TSocketBase):
         if not self.handle:
             raise TTransportException(type=TTransportException.NOT_OPEN,
                                       message='Transport not open')
-        sent = 0
-        have = len(buff)
-        while sent < have:
-            plus = self.handle.send(buff)
-            if plus == 0:
-                raise TTransportException(type=TTransportException.END_OF_FILE,
-                                          message='TSocket sent 0 bytes')
-            sent += plus
-            buff = buff[plus:]
+        self.handle.sendall(buff)
 
     def flush(self):
         pass


### PR DESCRIPTION
Just use the TCyBufferedTransport to wrap the framed transport. This gets most of the performance since there's ~ 1 call to read/write to the framed transport anyway.

Also simplify TFramedTransport - don't buffer writes; just wrap the transport in a buffered transport.
Also don't rewrite sendall.
