### PR TITLE
include the requirement flag on the thrift spec

### DIFF
--- a/tests/addressbook.py
+++ b/tests/addressbook.py
@@ -23,18 +23,18 @@ class PhoneType(object):
 
 class PhoneNumber(TPayload):
     thrift_spec = {
-        1: (TType.I32, "type", PhoneType),
-        2: (TType.STRING, "number"),
-        3: (TType.STRUCT, "mix_item", MixItem),
+        1: (TType.I32, "type", PhoneType, False),
+        2: (TType.STRING, "number", False),
+        3: (TType.STRUCT, "mix_item", MixItem, False),
     }
     default_spec = [("type", None), ("number", None), ("mix_item", None)]
 
 
 class Person(TPayload):
     thrift_spec = {
-        1: (TType.STRING, "name"),
+        1: (TType.STRING, "name", False),
         2: (TType.LIST, "phones", (TType.STRUCT, PhoneNumber)),
-        4: (TType.I32, "created_at"),
+        4: (TType.I32, "created_at", False),
     }
     default_spec = [("name", None), ("phones", None), ("created_at", None)]
 
@@ -49,7 +49,7 @@ class AddressBook(TPayload):
 
 class PersonNotExistsError(TException):
     thrift_spec = {
-        1: (TType.STRING, "message")
+        1: (TType.STRING, "message", False)
     }
     default_spec = [("message", None)]
 

--- a/tests/storm.py
+++ b/tests/storm.py
@@ -12,12 +12,12 @@ from thriftpy.thrift import (
 
 
 class JavaObjectArg(TPayload):
-    thrift_spec = {1: (TType.I32, 'int_arg'),
-                   2: (TType.I64, 'long_arg'),
-                   3: (TType.STRING, 'string_arg'),
-                   4: (TType.BOOL, 'bool_arg'),
-                   5: (TType.BINARY, 'binary_arg'),
-                   6: (TType.DOUBLE, 'double_arg')}
+    thrift_spec = {1: (TType.I32, 'int_arg', False),
+                   2: (TType.I64, 'long_arg', False),
+                   3: (TType.STRING, 'string_arg', False),
+                   4: (TType.BOOL, 'bool_arg', False),
+                   5: (TType.BINARY, 'binary_arg', False),
+                   6: (TType.DOUBLE, 'double_arg', False)}
 
 
 class JavaObject(TPayload):
@@ -135,8 +135,8 @@ class ClusterSummary(TPayload):
 
 
 class ErrorInfo(TPayload):
-    thrift_spec = {1: (TType.STRING, 'error'),
-                   2: (TType.I32, 'error_time_secs')}
+    thrift_spec = {1: (TType.STRING, 'error', False),
+                   2: (TType.I32, 'error_time_secs', False)}
 
 
 class BoltStats(TPayload):

--- a/tests/test_protocol_binary.py
+++ b/tests/test_protocol_binary.py
@@ -10,8 +10,8 @@ from thriftpy.protocol import binary as proto
 
 class TItem(TPayload):
     thrift_spec = {
-        1: (TType.I32, "id"),
-        2: (TType.LIST, "phones", (TType.STRING)),
+        1: (TType.I32, "id", False),
+        2: (TType.LIST, "phones", (TType.STRING), False),
     }
     default_spec = [("id", None), ("phones", None)]
 

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -5,4 +5,4 @@ from thriftpy.thrift import TType
 def test_set():
     s = load("type.thrift")
 
-    assert s.Set.thrift_spec == {1: (TType.SET, "a_set", TType.STRING)}
+    assert s.Set.thrift_spec == {1: (TType.SET, "a_set", TType.STRING, True)}

--- a/thriftpy/parser/__init__.py
+++ b/thriftpy/parser/__init__.py
@@ -122,12 +122,15 @@ def load(thrift_file, module_name=None, include_dirs=None):
 
         return const
 
-    def _ttype_spec(ttype, name):
+    def _ttype_spec(ttype, name, requirement=None):
         ttype = _ttype(ttype)
+        req = False
+        if requirement == 'required':
+            req = True
         if isinstance(ttype, int):
-            return ttype, name
+            return ttype, name, req
         else:
-            return ttype[0], name, ttype[1]
+            return ttype[0], name, ttype[1], req
 
     # load enums
     for name, enum in result["enums"].items():
@@ -163,7 +166,8 @@ def load(thrift_file, module_name=None, include_dirs=None):
                                         result["exceptions"].items()):
         thrift_spec, default_spec = {}, []
         for m in struct:
-            thrift_spec[m["id"]] = _ttype_spec(m["type"], m["name"])
+            thrift_spec[m["id"]] = _ttype_spec(m["type"], m["name"],
+                                               m["requirement"])
             default = _lookup_value(m["value"]) if m["value"] else None
             default_spec.append((m["name"], default))
         struct_cls = getattr(thrift_schema, name)

--- a/thriftpy/protocol/binary.py
+++ b/thriftpy/protocol/binary.py
@@ -145,11 +145,11 @@ def write_val(outbuf, ttype, val, spec=None):
     elif ttype == TType.STRUCT:
         for fid in iter(val.thrift_spec):
             f_spec = val.thrift_spec[fid]
-            if len(f_spec) == 2:
-                f_type, f_name = f_spec
+            if len(f_spec) == 3:
+                f_type, f_name, f_req = f_spec
                 f_container_spec = None
             else:
-                f_type, f_name, f_container_spec = f_spec
+                f_type, f_name, f_container_spec, f_req = f_spec
 
             v = getattr(val, f_name)
             if v is None:
@@ -291,11 +291,11 @@ def read_struct(inbuf, obj):
             skip(inbuf, f_type)
             continue
 
-        if len(obj.thrift_spec[fid]) == 2:
-            sf_type, f_name = obj.thrift_spec[fid]
+        if len(obj.thrift_spec[fid]) == 3:
+            sf_type, f_name, f_req = obj.thrift_spec[fid]
             f_container_spec = None
         else:
-            sf_type, f_name, f_container_spec = obj.thrift_spec[fid]
+            sf_type, f_name, f_container_spec, f_req = obj.thrift_spec[fid]
 
         # it really should equal here. but since we already wasted
         # space storing the duplicate info, let's check it.

--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -220,7 +220,7 @@ class TProcessor(object):
             if result.thrift_spec[k][1] == "success":
                 continue
 
-            _, exc_name, exc_cls = result.thrift_spec[k]
+            _, exc_name, exc_cls, _ = result.thrift_spec[k]
             if isinstance(e, exc_cls):
                 setattr(result, exc_name, e)
                 break


### PR DESCRIPTION
This amends the parser to include the `requirement` flag so it can be used for later validation.

I've used this in my own implementation of `TProcessor` (not included in these changes) to accomplish something like this:

```thrift
struct Thing {
    1: required string required_field;
}
```
```python
class ValidatingProcessor(TProcessor):
    def validate(self, result):
        obj = result.success
        for _, s in obj.thrift_spec.items():
            k = s[1]
            r = s[-1] # requirement will be at the end of the tuple
            v = getattr(obj, k)
            if v is None and r:
                raise TApplicationException(
                        message='{} is required'.format(k))

    def process(self, iprot, oprot):
        api, seqid, result, call = self.process_in(iprot)
        if isinstance(result, TApplicationException):
            self.send_exception(oprot, api, result, seqid)
            return
        try:
            result.success = call()
            self.validate(result)
        except TApplicationException as e:
            self.send_exception(oprot, api, e, seqid)
        except Exception as e:
            # raise if api don't have throws
            self.handle_exception(e, result)
        else:
            self.send_result(oprot, api, result, seqid)

```
Which, when called, produces:
```
$ python failing_client.py
<backtrace snip>
thriftpy.thrift.TApplicationException: `required_field` is required
```