### PR TITLE
Update loader to allow use and definition of types in the same file

### DIFF
--- a/tests/base.thrift
+++ b/tests/base.thrift
@@ -11,4 +11,7 @@ enum Code {
     UNKNOWN
 }
 
+typedef list<Code> codelist
+typedef map<Code, i64> codemap
+typedef set<Code> codeset
 typedef i64 timestamp

--- a/tests/parent.thrift
+++ b/tests/parent.thrift
@@ -4,4 +4,7 @@ struct Greet {
     1: optional base.Hello hello,
     2: optional base.timestamp date,
     3: optional base.Code code
+    4: optional base.codelist codelist
+    5: optional base.codeset codeset
+    6: optional base.codemap codemap
 }

--- a/tests/parser-cases/json/includes.json
+++ b/tests/parser-cases/json/includes.json
@@ -1,5 +1,5 @@
 {
-  "includes": ["structs.thrift", "enums.thrift"],
+  "includes": ["structs.thrift", "enums.thrift", "typedefs.thrift"],
   "namespaces": {},
   "enums": {},
   "structs": {
@@ -13,7 +13,13 @@
            "type": "enums.Enum1",
            "id": 2,
            "value": null,
-           "name": "enum1"}
+           "name": "enum1"},
+	  {"requirement": null,
+           "type": "typedefs.bytes",
+	   "id": 3,
+	   "value": null,
+	   "name": "bytes"
+	  }
       ]},
   "unions": {},
   "exceptions": {},

--- a/tests/parser-cases/json/typedefs.json
+++ b/tests/parser-cases/json/typedefs.json
@@ -2,7 +2,10 @@
   "typedefs": {
     "myInt": "i32",
     "str": "string",
-    "miniInt": "byte"
+    "miniInt": "byte",
+    "byteMap": ["map", "bytes", "int"],
+    "byteSet": ["set", "miniInt"], 
+    "bytes": ["list", "miniInt"]
   },
   "includes": [],
   "namespaces": {},

--- a/tests/parser-cases/thrift/includes.thrift
+++ b/tests/parser-cases/thrift/includes.thrift
@@ -1,7 +1,9 @@
 include "structs.thrift"
 include "enums.thrift"
+include "typedefs.thrift"
 
 struct Both {
   1: structs.Person person;
   2: enums.Enum1 enum1;
+  3: typedefs.bytes bytes;
 }

--- a/tests/parser-cases/thrift/typedefs.thrift
+++ b/tests/parser-cases/thrift/typedefs.thrift
@@ -1,3 +1,6 @@
 typedef i32 myInt
 typedef string str
 typedef byte miniInt
+typedef list<miniInt> bytes
+typedef set<miniInt> byteSet
+typedef map<bytes, int> byteMap

--- a/thriftpy/parser/__init__.py
+++ b/thriftpy/parser/__init__.py
@@ -101,15 +101,15 @@ def load(thrift_file, module_name=None, include_dirs=None):
             elif t in module._enums:
                 return TType.I32, getattr(module, t)
             elif t in module._typedefs:
-                return _ttype(module._typedefs[t])
+                return _ttype(module._typedefs[t], module)
             else:
                 return getattr(TType, t.upper())
         elif t[0] == "list":
-            return TType.LIST, _ttype(t[1])
+            return TType.LIST, _ttype(t[1], module)
         elif t[0] == "set":
-            return TType.SET, _ttype(t[1])
+            return TType.SET, _ttype(t[1], module)
         elif t[0] == "map":
-            return TType.MAP, (_ttype(t[1]), _ttype(t[2]))
+            return TType.MAP, (_ttype(t[1], module), _ttype(t[2], module))
         else:
             raise Exception("ttype parse error: {0}".format(t))
 


### PR DESCRIPTION
- Updates _ttypes method to always pass the module for non-base types.
- Adds types to base.thrift and parent.thrift for loader testing.
- Adds types to includes.thrift and typedefs.thrift to validate parsing.