### PR TITLE
Added service multiplexing support.

### DIFF
--- a/examples/multiplexer/dingdong.thrift
+++ b/examples/multiplexer/dingdong.thrift
@@ -1,0 +1,7 @@
+# ding service demo
+service DingService {
+    /*
+     * Sexy c style comment
+     */
+    string ding(),
+}

--- a/examples/multiplexer/multiplexed_client.py
+++ b/examples/multiplexer/multiplexed_client.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import thriftpy
+from thriftpy.rpc import client_context
+
+dd_thrift = thriftpy.load("dingdong.thrift", module_name="dd_thrift")
+pp_thrift = thriftpy.load("pingpong.thrift", module_name="pp_thrift")
+
+
+def main():
+    with client_context(dd_thrift.DingService, '127.0.0.1', 9090) as c:
+        # ring that doorbell
+        dong = c.ding()
+        print(dong)
+
+    with client_context(pp_thrift.PingService, '127.0.0.1', 9090) as c:
+        # play table tennis like a champ
+        pong = c.ping()
+        print(pong)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/multiplexer/multiplexed_server.py
+++ b/examples/multiplexer/multiplexed_server.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import thriftpy
+from thriftpy.protocol import TBinaryProtocolFactory
+from thriftpy.server import TThreadedServer
+from thriftpy.thrift import TProcessor, TMultiplexingProcessor
+from thriftpy.transport import TBufferedTransportFactory, TServerSocket
+
+
+dd_thrift = thriftpy.load("dingdong.thrift", module_name="dd_thrift")
+pp_thrift = thriftpy.load("pingpong.thrift", module_name="pp_thrift")
+
+
+class DingDispatcher(object):
+    def ding(self):
+        print("ding dong!")
+        return 'dong'
+
+
+class PingDispatcher(object):
+    def ping(self):
+        print("ping pong!")
+        return 'pong'
+
+
+def main():
+    dd_proc = TProcessor(dd_thrift.DingService, DingDispatcher())
+    pp_proc = TProcessor(pp_thrift.PingService, PingDispatcher())
+
+    mux_proc = TMultiplexingProcessor()
+    mux_proc.register_processor(dd_proc)
+    mux_proc.register_processor(pp_proc)
+
+    server = TThreadedServer(mux_proc, TServerSocket(),
+                             iprot_factory=TBinaryProtocolFactory(),
+                             itrans_factory=TBufferedTransportFactory())
+    server.serve()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/multiplexer/pingpong.thrift
+++ b/examples/multiplexer/pingpong.thrift
@@ -1,0 +1,7 @@
+# ping service demo
+service PingService {
+    /*
+     * Sexy c style comment
+     */
+    string ping(),
+}

--- a/tests/multiplexed.thrift
+++ b/tests/multiplexed.thrift
@@ -1,0 +1,7 @@
+service ThingOneService {
+    bool doThingOne();
+}
+
+service ThingTwoService {
+    bool doThingTwo();
+}

--- a/tests/test_multiplexed.py
+++ b/tests/test_multiplexed.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import os
+import multiprocessing
+import time
+
+import pytest
+
+import thriftpy
+from thriftpy.protocol import TBinaryProtocolFactory
+from thriftpy.rpc import client_context
+from thriftpy.server import TThreadedServer
+from thriftpy.thrift import TProcessor, TMultiplexingProcessor
+from thriftpy.transport import TBufferedTransportFactory, TServerSocket
+
+
+mux = thriftpy.load(os.path.join(os.path.dirname(__file__),
+                                 "multiplexed.thrift"))
+sock_path = "./thriftpy_test.sock"
+
+
+class DispatcherOne(object):
+    def doThingOne(self):
+        return True
+
+
+class DispatcherTwo(object):
+    def doThingTwo(self):
+        return True
+
+
+@pytest.fixture(scope="module")
+def server(request):
+    p1 = TProcessor(mux.ThingOneService, DispatcherOne())
+    p2 = TProcessor(mux.ThingTwoService, DispatcherTwo())
+
+    mux_proc = TMultiplexingProcessor()
+    mux_proc.register_processor(p1)
+    mux_proc.register_processor(p2)
+
+    _server = TThreadedServer(mux_proc, TServerSocket(unix_socket=sock_path),
+                              iprot_factory=TBinaryProtocolFactory(),
+                              itrans_factory=TBufferedTransportFactory())
+    ps = multiprocessing.Process(target=_server.serve)
+    ps.start()
+    time.sleep(0.1)
+
+    def fin():
+        if ps.is_alive():
+            ps.terminate()
+        try:
+            os.remove(sock_path)
+        except IOError:
+            pass
+    request.addfinalizer(fin)
+
+
+def client_one(timeout=3000):
+    return client_context(mux.ThingOneService, unix_socket=sock_path,
+                          timeout=timeout)
+
+
+def client_two(timeout=3000):
+    return client_context(mux.ThingTwoService, unix_socket=sock_path,
+                          timeout=timeout)
+
+
+def test_multiplexed_server(server):
+    with client_one() as c:
+        assert c.doThingOne() is True
+    with client_two() as c:
+        assert c.doThingTwo() is True

--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -203,6 +203,7 @@ class TProcessor(object):
             return getattr(self._handler, api)(
                 *(args.__dict__[k] for k in api_args)
             )
+
         return api, seqid, result, call
 
     def send_exception(self, oprot, api, exc, seqid):
@@ -289,9 +290,11 @@ class TMultiplexingProcessor(TProcessor):
         # convert kwargs to args
         api_args = [args.thrift_spec[k][1]
                     for k in sorted(args.thrift_spec)]
-        call = lambda: getattr(proc._handler, api)(
-            *(args.__dict__[k] for k in api_args)
-        )
+
+        def call():
+            f = getattr(proc._handler, api)
+            return f(*(args.__dict__[k] for k in api_args))
+
         return api, seqid, result, call
 
 


### PR DESCRIPTION
This is a re-do of #79.

This introduces a TMultiplexingProcessor class which extends TProcessor. This adds the ability for developers to develop services that implement multiple Thrift interfaces. It is inspired by the TMultiplexedProcessor from the Thrift Java library.

Example here: http://stackoverflow.com/questions/19614648/service-multiplexing-using-apache-thrift