### PR TITLE
add annotation field to trace data

### DIFF
--- a/thriftpy/contrib/tracking/__init__.py
+++ b/thriftpy/contrib/tracking/__init__.py
@@ -89,7 +89,8 @@ class TTrackedClient(TClient):
                 api=_api,
                 status=status,
                 start=self.send_start,
-                end=int(time.time() * 1000)
+                end=int(time.time() * 1000),
+                annotation=self.tracer.annotation
             )
             self.tracer.record(header_info, exception)
 

--- a/thriftpy/contrib/tracking/tracker.py
+++ b/thriftpy/contrib/tracking/tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import contextlib
 import threading
 import uuid
 
@@ -33,6 +34,19 @@ class TrackerBase(object):
 
     def record(self, header, exception):
         pass
+
+    @classmethod
+    @contextlib.contextmanager
+    def annotate(cls, **kwargs):
+        ctx.annotation = kwargs
+        try:
+            yield ctx.annotation
+        finally:
+            del ctx.annotation
+
+    @property
+    def annotation(self):
+        return ctx.annotation if hasattr(ctx, "annotation") else {}
 
     def get_request_id(self):
         if hasattr(ctx, "header"):

--- a/thriftpy/contrib/tracking/tracking.thrift
+++ b/thriftpy/contrib/tracking/tracking.thrift
@@ -10,6 +10,7 @@ struct RequestInfo {
     6: bool status // request status
     7: i64 start // start timestamp
     8: i64 end // end timestamp
+    9: map<string, string> annotation // application-level key-value datas
 }
 
 /*


### PR DESCRIPTION
Client side can add arbitrary key-value data to recorded trace data.

```python
from tracker_handler import Tracker

# will add {"key": "value", "hello": "world} to recorded data
with Tracker.annotate(key="value", hello="world):
    c.ping()

# or

# will add {"x": "123", "y": "c.ping()"} to recorded data
with Tracker.annotate() as ann:
    ann.update({"x": "123", "y": "c.ping()"})
    c.ping()

# this will not work
with Tracker.annotate() as ann:
    c.ping()
    ann["key"] = "value
```

@wooparadog @lxyu 