### PR TITLE
Multiplex using service_name

### DIFF
--- a/examples/multiplexer/multiplexed_client.py
+++ b/examples/multiplexer/multiplexed_client.py
@@ -2,7 +2,10 @@
 
 import thriftpy
 from thriftpy.rpc import client_context
-from thriftpy.protocol import TBinaryProtocolFactory, TMultiplexingProtocolFactory
+from thriftpy.protocol import (
+    TBinaryProtocolFactory,
+    TMultiplexingProtocolFactory
+    )
 
 dd_thrift = thriftpy.load("dingdong.thrift", module_name="dd_thrift")
 pp_thrift = thriftpy.load("pingpong.thrift", module_name="pp_thrift")
@@ -11,15 +14,15 @@ pp_thrift = thriftpy.load("pingpong.thrift", module_name="pp_thrift")
 def main():
     binary_factory = TBinaryProtocolFactory()
     dd_factory = TMultiplexingProtocolFactory(binary_factory, "dd_thrift")
-    with client_context(dd_thrift.DingService, '127.0.0.1', 9090, 
-        proto_factory=dd_factory) as c:
+    with client_context(dd_thrift.DingService, '127.0.0.1', 9090,
+                        proto_factory=dd_factory) as c:
         # ring that doorbell
         dong = c.ding()
         print(dong)
 
     pp_factory = TMultiplexingProtocolFactory(binary_factory, "pp_thrift")
-    with client_context(pp_thrift.PingService, '127.0.0.1', 9090, 
-        proto_factory=pp_factory) as c:
+    with client_context(pp_thrift.PingService, '127.0.0.1', 9090,
+                        proto_factory=pp_factory) as c:
         # play table tennis like a champ
         pong = c.ping()
         print(pong)

--- a/examples/multiplexer/multiplexed_client.py
+++ b/examples/multiplexer/multiplexed_client.py
@@ -10,17 +10,21 @@ from thriftpy.protocol import (
 dd_thrift = thriftpy.load("dingdong.thrift", module_name="dd_thrift")
 pp_thrift = thriftpy.load("pingpong.thrift", module_name="pp_thrift")
 
+DD_SERVICE_NAME = "dd_thrift"
+PP_SERVICE_NAME = "pp_thrift"
+
+
 
 def main():
     binary_factory = TBinaryProtocolFactory()
-    dd_factory = TMultiplexingProtocolFactory(binary_factory, "dd_thrift")
+    dd_factory = TMultiplexingProtocolFactory(binary_factory, DD_SERVICE_NAME)
     with client_context(dd_thrift.DingService, '127.0.0.1', 9090,
                         proto_factory=dd_factory) as c:
         # ring that doorbell
         dong = c.ding()
         print(dong)
 
-    pp_factory = TMultiplexingProtocolFactory(binary_factory, "pp_thrift")
+    pp_factory = TMultiplexingProtocolFactory(binary_factory, PP_SERVICE_NAME)
     with client_context(pp_thrift.PingService, '127.0.0.1', 9090,
                         proto_factory=pp_factory) as c:
         # play table tennis like a champ

--- a/examples/multiplexer/multiplexed_client.py
+++ b/examples/multiplexer/multiplexed_client.py
@@ -2,18 +2,24 @@
 
 import thriftpy
 from thriftpy.rpc import client_context
+from thriftpy.protocol import TBinaryProtocolFactory, TMultiplexingProtocolFactory
 
 dd_thrift = thriftpy.load("dingdong.thrift", module_name="dd_thrift")
 pp_thrift = thriftpy.load("pingpong.thrift", module_name="pp_thrift")
 
 
 def main():
-    with client_context(dd_thrift.DingService, '127.0.0.1', 9090) as c:
+    binary_factory = TBinaryProtocolFactory()
+    dd_factory = TMultiplexingProtocolFactory(binary_factory, "dd_thrift")
+    with client_context(dd_thrift.DingService, '127.0.0.1', 9090, 
+        proto_factory=dd_factory) as c:
         # ring that doorbell
         dong = c.ding()
         print(dong)
 
-    with client_context(pp_thrift.PingService, '127.0.0.1', 9090) as c:
+    pp_factory = TMultiplexingProtocolFactory(binary_factory, "pp_thrift")
+    with client_context(pp_thrift.PingService, '127.0.0.1', 9090, 
+        proto_factory=pp_factory) as c:
         # play table tennis like a champ
         pong = c.ping()
         print(pong)

--- a/examples/multiplexer/multiplexed_server.py
+++ b/examples/multiplexer/multiplexed_server.py
@@ -28,8 +28,8 @@ def main():
     pp_proc = TProcessor(pp_thrift.PingService, PingDispatcher())
 
     mux_proc = TMultiplexingProcessor()
-    mux_proc.register_processor(dd_proc)
-    mux_proc.register_processor(pp_proc)
+    mux_proc.register_processor("dd_thrift", dd_proc)
+    mux_proc.register_processor("pp_thrift", pp_proc)
 
     server = TThreadedServer(mux_proc, TServerSocket(),
                              iprot_factory=TBinaryProtocolFactory(),

--- a/examples/multiplexer/multiplexed_server.py
+++ b/examples/multiplexer/multiplexed_server.py
@@ -10,6 +10,8 @@ from thriftpy.transport import TBufferedTransportFactory, TServerSocket
 dd_thrift = thriftpy.load("dingdong.thrift", module_name="dd_thrift")
 pp_thrift = thriftpy.load("pingpong.thrift", module_name="pp_thrift")
 
+DD_SERVICE_NAME = "dd_thrift"
+PP_SERVICE_NAME = "pp_thrift"
 
 class DingDispatcher(object):
     def ding(self):
@@ -28,8 +30,8 @@ def main():
     pp_proc = TProcessor(pp_thrift.PingService, PingDispatcher())
 
     mux_proc = TMultiplexingProcessor()
-    mux_proc.register_processor("dd_thrift", dd_proc)
-    mux_proc.register_processor("pp_thrift", pp_proc)
+    mux_proc.register_processor(DD_SERVICE_NAME, dd_proc)
+    mux_proc.register_processor(PP_SERVICE_NAME, pp_proc)
 
     server = TThreadedServer(mux_proc, TServerSocket(),
                              iprot_factory=TBinaryProtocolFactory(),

--- a/tests/test_multiplexed.py
+++ b/tests/test_multiplexed.py
@@ -9,8 +9,10 @@ import time
 import pytest
 
 import thriftpy
-from thriftpy.protocol import TBinaryProtocolFactory
-from thrift.protocol import TMultiplexingProtocolFactory
+from thriftpy.protocol import (
+    TBinaryProtocolFactory,
+    TMultiplexingProtocolFactory
+    )
 from thriftpy.rpc import client_context
 from thriftpy.server import TThreadedServer
 from thriftpy.thrift import TProcessor, TMultiplexingProcessor

--- a/tests/test_multiplexed.py
+++ b/tests/test_multiplexed.py
@@ -9,7 +9,7 @@ import time
 import pytest
 
 import thriftpy
-from thriftpy.protocol import TBinaryProtocolFactory
+from thriftpy.protocol import TBinaryProtocolFactory, TMultiplexingProtocolFactory
 from thriftpy.rpc import client_context
 from thriftpy.server import TThreadedServer
 from thriftpy.thrift import TProcessor, TMultiplexingProcessor
@@ -37,8 +37,8 @@ def server(request):
     p2 = TProcessor(mux.ThingTwoService, DispatcherTwo())
 
     mux_proc = TMultiplexingProcessor()
-    mux_proc.register_processor(p1)
-    mux_proc.register_processor(p2)
+    mux_proc.register_processor("ThingOneService", p1)
+    mux_proc.register_processor("ThingTwoService", p2)
 
     _server = TThreadedServer(mux_proc, TServerSocket(unix_socket=sock_path),
                               iprot_factory=TBinaryProtocolFactory(),
@@ -58,13 +58,19 @@ def server(request):
 
 
 def client_one(timeout=3000):
+    binary_factory = TBinaryProtocolFactory()
+    multiplexing_factory = TMultiplexingProtocolFactory(binary_factory, "ThingOneService")
     return client_context(mux.ThingOneService, unix_socket=sock_path,
-                          timeout=timeout)
+                          timeout=timeout,
+                          proto_factory=multiplexing_factory)
 
 
 def client_two(timeout=3000):
+    binary_factory = TBinaryProtocolFactory()
+    multiplexing_factory = TMultiplexingProtocolFactory(binary_factory, "ThingTwoService")
     return client_context(mux.ThingTwoService, unix_socket=sock_path,
-                          timeout=timeout)
+                          timeout=timeout,
+                          proto_factory=multiplexing_factory)
 
 
 def test_multiplexed_server(server):

--- a/tests/test_multiplexed.py
+++ b/tests/test_multiplexed.py
@@ -9,7 +9,8 @@ import time
 import pytest
 
 import thriftpy
-from thriftpy.protocol import TBinaryProtocolFactory, TMultiplexingProtocolFactory
+from thriftpy.protocol import TBinaryProtocolFactory
+from thrift.protocol import TMultiplexingProtocolFactory
 from thriftpy.rpc import client_context
 from thriftpy.server import TThreadedServer
 from thriftpy.thrift import TProcessor, TMultiplexingProcessor
@@ -59,7 +60,8 @@ def server(request):
 
 def client_one(timeout=3000):
     binary_factory = TBinaryProtocolFactory()
-    multiplexing_factory = TMultiplexingProtocolFactory(binary_factory, "ThingOneService")
+    multiplexing_factory = TMultiplexingProtocolFactory(binary_factory,
+                                                        "ThingOneService")
     return client_context(mux.ThingOneService, unix_socket=sock_path,
                           timeout=timeout,
                           proto_factory=multiplexing_factory)
@@ -67,7 +69,8 @@ def client_one(timeout=3000):
 
 def client_two(timeout=3000):
     binary_factory = TBinaryProtocolFactory()
-    multiplexing_factory = TMultiplexingProtocolFactory(binary_factory, "ThingTwoService")
+    multiplexing_factory = TMultiplexingProtocolFactory(binary_factory,
+                                                        "ThingTwoService")
     return client_context(mux.ThingTwoService, unix_socket=sock_path,
                           timeout=timeout,
                           proto_factory=multiplexing_factory)

--- a/thriftpy/protocol/__init__.py
+++ b/thriftpy/protocol/__init__.py
@@ -21,4 +21,4 @@ else:
 __all__ = ['TBinaryProtocol', 'TBinaryProtocolFactory',
            'TCyBinaryProtocol', 'TCyBinaryProtocolFactory',
            'TJSONProtocol', 'TJSONProtocolFactory',
-           'TMultiplexingProtocol']
+           'TMultiplexingProtocol', 'TMultiplexingProtocolFactory']

--- a/thriftpy/protocol/__init__.py
+++ b/thriftpy/protocol/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 from .binary import TBinaryProtocol, TBinaryProtocolFactory
 from .json import TJSONProtocol, TJSONProtocolFactory
+from .multiplex import TMultiplexingProtocol, TMultiplexingProtocolFactory
 
 from thriftpy._compat import PYPY, CYTHON
 if not PYPY:
@@ -19,4 +20,5 @@ else:
 
 __all__ = ['TBinaryProtocol', 'TBinaryProtocolFactory',
            'TCyBinaryProtocol', 'TCyBinaryProtocolFactory',
-           'TJSONProtocol', 'TJSONProtocolFactory']
+           'TJSONProtocol', 'TJSONProtocolFactory',
+           'TMultiplexingProtocol']

--- a/thriftpy/protocol/multiplex.py
+++ b/thriftpy/protocol/multiplex.py
@@ -24,6 +24,7 @@ class TMultiplexingProtocol(object):
             self.service_name + TMultiplexingProcessor.Separator + name,
             ttype, seqid)
 
+
 class TMultiplexingProtocolFactory(object):
 
     def __init__(self, proto_factory, service_name):

--- a/thriftpy/protocol/multiplex.py
+++ b/thriftpy/protocol/multiplex.py
@@ -21,7 +21,7 @@ class TMultiplexingProtocol(object):
 
     def write_message_begin(self, name, ttype, seqid):
         self.proto.write_message_begin(
-            self.service_name + TMultiplexingProcessor.Separator + name,
+            self.service_name + TMultiplexingProcessor.SEPARATOR + name,
             ttype, seqid)
 
 

--- a/thriftpy/protocol/multiplex.py
+++ b/thriftpy/protocol/multiplex.py
@@ -1,0 +1,36 @@
+from thriftpy.thrift import TMultiplexingProcessor
+
+
+class TMultiplexingProtocol(object):
+
+    """
+
+    Multiplex protocol
+
+    for writing message begin, it prepend the service name to the api
+    for other functions, it simply delegate to the original protocol
+
+    """
+
+    def __init__(self, proto, service_name):
+        self.service_name = service_name
+        self.proto = proto
+
+    def __getattr__(self, name):
+        return getattr(self.proto, name)
+
+    def write_message_begin(self, name, ttype, seqid):
+        self.proto.write_message_begin(
+            self.service_name + TMultiplexingProcessor.Separator + name,
+            ttype, seqid)
+
+class TMultiplexingProtocolFactory(object):
+
+    def __init__(self, proto_factory, service_name):
+        self.proto_factory = proto_factory
+        self.service_name = service_name
+
+    def get_protocol(self, trans):
+        proto = self.proto_factory.get_protocol(trans)
+        multi_proto = TMultiplexingProtocol(proto, self.service_name)
+        return multi_proto

--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -247,7 +247,7 @@ class TProcessor(object):
 
 
 class TMultiplexingProcessor(TProcessor):
-    Separator = ":"
+    SEPARATOR = ":"
 
     processors = {}
     service_map = {}
@@ -268,7 +268,7 @@ class TMultiplexingProcessor(TProcessor):
     def process_in(self, iprot):
         api, type, seqid = iprot.read_message_begin()
 
-        service_name, api = api.split(TMultiplexingProcessor.Separator)
+        service_name, api = api.split(TMultiplexingProcessor.SEPARATOR)
 
         if service_name not in self.processors:
             iprot.skip(TType.STRUCT)

--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -10,7 +10,6 @@
 from __future__ import absolute_import
 
 import functools
-import inspect
 
 from ._compat import init_func_generator, with_metaclass
 
@@ -257,7 +256,6 @@ class TMultiplexingProcessor(TProcessor):
         pass
 
     def register_processor(self, service_name, processor):
-        service = processor._service
 
         if service_name in self.processors:
             raise TApplicationException(

--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -249,10 +249,8 @@ class TProcessor(object):
 class TMultiplexingProcessor(TProcessor):
     SEPARATOR = ":"
 
-    processors = {}
-    service_map = {}
-
     def __init__(self):
+        self.processors = {}
         pass
 
     def register_processor(self, service_name, processor):


### PR DESCRIPTION
Fix https://github.com/eleme/thriftpy/issues/114

Change the signature of register_processor to (service_name, processor)
and add TMultiplexingProtocol, which use separator (“:”) to join
service_name and function as the api

Modified test and example