### PR TITLE
fix cy framed transport bug

### DIFF
--- a/tests/test_cytransport.py
+++ b/tests/test_cytransport.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from thriftpy._compat import PYPY
+
+pytestmark = pytest.mark.skipif(PYPY, reason="cython not enabled in pypy.")
+
+if not PYPY:
+    from thriftpy.transport.framed import TCyFramedTransport
+    from thriftpy.transport.buffered import TCyBufferedTransport
+    from thriftpy.transport import TMemoryBuffer, TTransportException
+
+
+def test_transport_mismatch():
+    s = TMemoryBuffer()
+
+    t1 = TCyBufferedTransport(s)
+    t1.write(b"\x80\x01\x00\x01\x00\x00\x00\x04ping hello world")
+    t1.flush()
+
+    with pytest.raises(TTransportException) as exc:
+        t2 = TCyFramedTransport(s)
+        t2.read(4)
+
+    assert "No frame" in str(exc.value)
+
+
+def test_buffered_read():
+    s = TMemoryBuffer()
+
+    t = TCyBufferedTransport(s)
+    t.write(b"ping")
+    t.flush()
+
+    assert t.read(4) == b"ping"

--- a/thriftpy/transport/buffered/cybuffered.pyx
+++ b/thriftpy/transport/buffered/cybuffered.pyx
@@ -60,7 +60,11 @@ cdef class TCyBufferedTransport(CyTransportBase):
             raise MemoryError("Write to buffer error")
 
     cdef c_read(self, int sz, char* out):
+        if sz <= 0:
+            return 0
+
         self.read_trans(sz, out)
+        return sz
 
     cdef read_trans(self, int sz, char *out):
         cdef int i = self.rbuf.read_trans(self.trans, sz, out)

--- a/thriftpy/transport/cybase.pyx
+++ b/thriftpy/transport/cybase.pyx
@@ -27,6 +27,9 @@ cdef class TCyBuffer(object):
             int cap = self.buf_size - self.data_size
             int remain = cap - self.cur
 
+        if sz <= 0:
+            return 0
+
         if remain < sz:
             self.move_to_start()
 
@@ -44,6 +47,9 @@ cdef class TCyBuffer(object):
 
     cdef read_trans(self, trans, int sz, char *out):
         cdef int cap, new_data_len
+
+        if sz <= 0:
+            return 0
 
         if self.data_size < sz:
             if self.buf_size < sz:


### PR DESCRIPTION
When server uses TCyFramedTransport and client uses TCyBufferedTransport,
segmentation fault may happen in server end.

@lxyu 