### PR TITLE
add method for manually setting counter for seq

### DIFF
--- a/thriftpy/contrib/tracking/tracker.py
+++ b/thriftpy/contrib/tracking/tracker.py
@@ -37,6 +37,24 @@ class TrackerBase(object):
 
     @classmethod
     @contextlib.contextmanager
+    def counter(cls, init=0):
+        """Context for manually setting counter of seq number.
+
+        :init: init value
+        """
+        if not hasattr(ctx, "counter"):
+            ctx.counter = 0
+
+        old = ctx.counter
+        ctx.counter = init
+
+        try:
+            yield
+        finally:
+            ctx.counter = old
+
+    @classmethod
+    @contextlib.contextmanager
     def annotate(cls, **kwargs):
         ctx.annotation = kwargs
         try:


### PR DESCRIPTION
```python
c.api1()  # seq = '1'
c.api2()  # seq = '2'

# reset counter to 0
with Tracker.counter():
    c.api3()  # seq = '1'
    c.api4()  # seq = '2'
    c.api5()  # seq = '3'

# resume 
c.api6()  # seq = '3'
c.api7()  # seq = '4'
```

@wooparadog @lxyu 