### PR TITLE
Shutdown socket before closing it.

### DIFF
--- a/thriftpy/transport/socket.py
+++ b/thriftpy/transport/socket.py
@@ -26,6 +26,7 @@ class TSocketBase(TTransportBase):
 
     def close(self):
         if self.handle:
+            self.handle.shutdown(socket.SHUT_RDWR)
             self.handle.close()
             self.handle = None
 


### PR DESCRIPTION
As stated in socket module, the close() method releases the resource associated with the
connection but does not necessarily close the connection. Thus, this commit introduces a call to
the 'shutdown()' method before closing the socket.