### PR TITLE
Fixes parsing of const defs with separators

### DIFF
--- a/tests/const.thrift
+++ b/tests/const.thrift
@@ -8,6 +8,9 @@ const double DOUBLE_CONST = 123.456
 const string DOUBLE_QUOTED_CONST = "hello"
 const string SINGLE_QUOTED_CONST = 'hello'
 
+const string CONST_WITH_SEP1 = "hello",
+const string CONST_WITH_SEP2 = "hello";
+
 const list<i32> I32_LIST_CONST = [1, 2, 3]
 const list<double> DOUBLE_LIST_CONST = [1.1, 2.2, 3.3]
 const list<string> STRING_LIST_CONST = ["hello", "world"]

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -20,6 +20,11 @@ def test_string_const():
     assert "hello" == const.SINGLE_QUOTED_CONST
 
 
+def test_const_with_sep():
+    assert "hello" == const.CONST_WITH_SEP1
+    assert "hello" == const.CONST_WITH_SEP2
+
+
 def test_list_const():
     assert [1, 2, 3] == const.I32_LIST_CONST
     assert [1.1, 2.2, 3.3] == const.DOUBLE_LIST_CONST

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -91,7 +91,8 @@ def p_definition_unit(p):
 
 
 def p_const(p):
-    '''const : CONST field_type IDENTIFIER '=' const_value'''
+    '''const : CONST field_type IDENTIFIER '=' const_value
+             | CONST field_type IDENTIFIER '=' const_value sep'''
 
     try:
         val = _cast(p[2])(p[5])


### PR DESCRIPTION
The Thrift IDL grammar specifies that constant definitions may be terminated with a separator, which was not included in the thriftpy parser.