### PR TITLE
Make cython optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,12 +46,11 @@ PYPY = "__pypy__" in sys.modules
 UNIX = platform.system() in ("Linux", "Darwin")
 
 # only build ext in CPython with UNIX platform
-if UNIX and not PYPY:
-    # rebuild .c files if cython available
-    if CYTHON:
-        cythonize("thriftpy/transport/cybase.pyx")
-        cythonize("thriftpy/transport/**/*.pyx")
-        cythonize("thriftpy/protocol/cybin/cybin.pyx")
+if CYTHON and UNIX and not PYPY:
+    # build .c files if cython available
+    cythonize("thriftpy/transport/cybase.pyx")
+    cythonize("thriftpy/transport/**/*.pyx")
+    cythonize("thriftpy/protocol/cybin/cybin.pyx")
 
     ext_modules.append(Extension("thriftpy.transport.cybase",
                                  ["thriftpy/transport/cybase.c"]))


### PR DESCRIPTION
The .c files referenced in setup.py do not exist. If cython creates them (?) then this patch fixes the problem.

# Before

    $ git clone https://github.com/eleme/thriftpy
    Cloning into 'thriftpy'...
    remote: Counting objects: 2664, done.
    remote: Total 2664 (delta 0), reused 0 (delta 0), pack-reused 2664
    Receiving objects: 100% (2664/2664), 525.98 KiB | 913.00 KiB/s, done.
    Resolving deltas: 100% (1724/1724), done.
    Checking connectivity... done.
    $ cd thriftpy/
    $ git show
    commit 5319ad230d29d2c56456022529239339c0f361eb
    Merge: 193c752 3cedc9e
    Author: Lx Yu <i@lxyu.net>
    Date:   Thu Jun 18 16:11:27 2015 +0800

        Merge pull request #140 from maralla/unix_socket
        
        fix unix socket in tests
    $ python setup.py build
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-2.7
    creating build/lib.linux-x86_64-2.7/thriftpy
    copying thriftpy/server.py -> build/lib.linux-x86_64-2.7/thriftpy
    copying thriftpy/thrift.py -> build/lib.linux-x86_64-2.7/thriftpy
    copying thriftpy/tornado.py -> build/lib.linux-x86_64-2.7/thriftpy
    copying thriftpy/utils.py -> build/lib.linux-x86_64-2.7/thriftpy
    copying thriftpy/rpc.py -> build/lib.linux-x86_64-2.7/thriftpy
    copying thriftpy/hook.py -> build/lib.linux-x86_64-2.7/thriftpy
    copying thriftpy/_compat.py -> build/lib.linux-x86_64-2.7/thriftpy
    copying thriftpy/__init__.py -> build/lib.linux-x86_64-2.7/thriftpy
    creating build/lib.linux-x86_64-2.7/thriftpy/contrib
    copying thriftpy/contrib/__init__.py -> build/lib.linux-x86_64-2.7/thriftpy/contrib
    creating build/lib.linux-x86_64-2.7/thriftpy/protocol
    copying thriftpy/protocol/binary.py -> build/lib.linux-x86_64-2.7/thriftpy/protocol
    copying thriftpy/protocol/json.py -> build/lib.linux-x86_64-2.7/thriftpy/protocol
    copying thriftpy/protocol/multiplex.py -> build/lib.linux-x86_64-2.7/thriftpy/protocol
    copying thriftpy/protocol/exc.py -> build/lib.linux-x86_64-2.7/thriftpy/protocol
    copying thriftpy/protocol/__init__.py -> build/lib.linux-x86_64-2.7/thriftpy/protocol
    creating build/lib.linux-x86_64-2.7/thriftpy/transport
    copying thriftpy/transport/socket.py -> build/lib.linux-x86_64-2.7/thriftpy/transport
    copying thriftpy/transport/__init__.py -> build/lib.linux-x86_64-2.7/thriftpy/transport
    creating build/lib.linux-x86_64-2.7/thriftpy/parser
    copying thriftpy/parser/lexer.py -> build/lib.linux-x86_64-2.7/thriftpy/parser
    copying thriftpy/parser/parser.py -> build/lib.linux-x86_64-2.7/thriftpy/parser
    copying thriftpy/parser/exc.py -> build/lib.linux-x86_64-2.7/thriftpy/parser
    copying thriftpy/parser/__init__.py -> build/lib.linux-x86_64-2.7/thriftpy/parser
    creating build/lib.linux-x86_64-2.7/thriftpy/contrib/tracking
    copying thriftpy/contrib/tracking/tracker.py -> build/lib.linux-x86_64-2.7/thriftpy/contrib/tracking
    copying thriftpy/contrib/tracking/__init__.py -> build/lib.linux-x86_64-2.7/thriftpy/contrib/tracking
    creating build/lib.linux-x86_64-2.7/thriftpy/transport/memory
    copying thriftpy/transport/memory/__init__.py -> build/lib.linux-x86_64-2.7/thriftpy/transport/memory
    creating build/lib.linux-x86_64-2.7/thriftpy/transport/buffered
    copying thriftpy/transport/buffered/__init__.py -> build/lib.linux-x86_64-2.7/thriftpy/transport/buffered
    creating build/lib.linux-x86_64-2.7/thriftpy/transport/framed
    copying thriftpy/transport/framed/__init__.py -> build/lib.linux-x86_64-2.7/thriftpy/transport/framed
    copying thriftpy/contrib/tracking/tracking.thrift -> build/lib.linux-x86_64-2.7/thriftpy/contrib/tracking
    running build_ext
    building 'thriftpy.transport.cybase' extension
    creating build/temp.linux-x86_64-2.7
    creating build/temp.linux-x86_64-2.7/thriftpy
    creating build/temp.linux-x86_64-2.7/thriftpy/transport
    gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -I/usr/kerberos/include -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/include/python2.7 -c thriftpy/transport/cybase.c -o build/temp.linux-x86_64-2.7/thriftpy/transport/cybase.o
    gcc: thriftpy/transport/cybase.c: No such file or directory
    gcc: no input files
    error: command 'gcc' failed with exit status 1

# After

    $ python setup.py build
    running build
    running build_py
    creating build/lib
    creating build/lib/thriftpy
    copying thriftpy/server.py -> build/lib/thriftpy
    copying thriftpy/thrift.py -> build/lib/thriftpy
    copying thriftpy/tornado.py -> build/lib/thriftpy
    copying thriftpy/utils.py -> build/lib/thriftpy
    copying thriftpy/rpc.py -> build/lib/thriftpy
    copying thriftpy/hook.py -> build/lib/thriftpy
    copying thriftpy/_compat.py -> build/lib/thriftpy
    copying thriftpy/__init__.py -> build/lib/thriftpy
    creating build/lib/thriftpy/contrib
    copying thriftpy/contrib/__init__.py -> build/lib/thriftpy/contrib
    creating build/lib/thriftpy/protocol
    copying thriftpy/protocol/binary.py -> build/lib/thriftpy/protocol
    copying thriftpy/protocol/json.py -> build/lib/thriftpy/protocol
    copying thriftpy/protocol/multiplex.py -> build/lib/thriftpy/protocol
    copying thriftpy/protocol/exc.py -> build/lib/thriftpy/protocol
    copying thriftpy/protocol/__init__.py -> build/lib/thriftpy/protocol
    creating build/lib/thriftpy/transport
    copying thriftpy/transport/socket.py -> build/lib/thriftpy/transport
    copying thriftpy/transport/__init__.py -> build/lib/thriftpy/transport
    creating build/lib/thriftpy/parser
    copying thriftpy/parser/lexer.py -> build/lib/thriftpy/parser
    copying thriftpy/parser/parser.py -> build/lib/thriftpy/parser
    copying thriftpy/parser/exc.py -> build/lib/thriftpy/parser
    copying thriftpy/parser/__init__.py -> build/lib/thriftpy/parser
    creating build/lib/thriftpy/contrib/tracking
    copying thriftpy/contrib/tracking/tracker.py -> build/lib/thriftpy/contrib/tracking
    copying thriftpy/contrib/tracking/__init__.py -> build/lib/thriftpy/contrib/tracking
    creating build/lib/thriftpy/transport/memory
    copying thriftpy/transport/memory/__init__.py -> build/lib/thriftpy/transport/memory
    creating build/lib/thriftpy/transport/buffered
    copying thriftpy/transport/buffered/__init__.py -> build/lib/thriftpy/transport/buffered
    creating build/lib/thriftpy/transport/framed
    copying thriftpy/transport/framed/__init__.py -> build/lib/thriftpy/transport/framed
    copying thriftpy/contrib/tracking/tracking.thrift -> build/lib/thriftpy/contrib/tracking