### PR TITLE
validate field types when write data to transport

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import thriftpy
+from thriftpy.thrift import parse_spec, TType
 
 
 def test_obj_equalcheck():
@@ -37,3 +38,20 @@ def test_default_value():
     ab = thriftpy.load("addressbook.thrift")
 
     assert ab.PhoneNumber().type == ab.PhoneType.MOBILE
+
+
+def test_parse_spec():
+    ab = thriftpy.load("addressbook.thrift")
+
+    cases = [
+        ((TType.I32, None), "I32"),
+        ((TType.STRUCT, ab.PhoneNumber), "PhoneNumber"),
+        ((TType.LIST, TType.I32), "LIST<I32>"),
+        ((TType.LIST, (TType.STRUCT, ab.PhoneNumber)), "LIST<PhoneNumber>"),
+        ((TType.MAP, (TType.STRING, (
+            TType.LIST, (TType.MAP, (TType.STRING, TType.STRING))))),
+         "MAP<STRING, LIST<MAP<STRING, STRING>>>")
+    ]
+
+    for spec, res in cases:
+        assert parse_spec(*spec) == res


### PR DESCRIPTION
When type mismatched this kind of exception will be rasied:
```
TDecodeException: Field 'amount(1)' of 'TGift' needs type 'MAP<STRING, TFood>', but the value is `'hello'`
```

@lxyu 