### PR TITLE
Since Python 3.3, socket.error has been merged into OSError.

### DIFF
--- a/thriftpy/tornado.py
+++ b/thriftpy/tornado.py
@@ -68,7 +68,7 @@ class TTornadoStreamTransport(TTransportBase):
         try:
             yield self.with_timeout(timeout, self.stream.connect(
                 (self.host, self.port)))
-        except (socket.error, IOError):
+        except (socket.error, OSError, IOError):
             message = 'could not connect to {}:{}'.format(self.host, self.port)
             raise TTransportException(
                 type=TTransportException.NOT_OPEN,
@@ -94,7 +94,7 @@ class TTornadoStreamTransport(TTransportBase):
     def io_exception_context(self):
         try:
             yield
-        except (socket.error, IOError) as e:
+        except (socket.error, OSError, IOError) as e:
             raise TTransportException(
                 type=TTransportException.END_OF_FILE,
                 message=str(e))

--- a/thriftpy/transport/socket.py
+++ b/thriftpy/transport/socket.py
@@ -31,7 +31,7 @@ class TSocketBase(TTransportBase):
         try:
             self.handle.shutdown(socket.SHUT_RDWR)
             self.handle.close()
-        except socket.error:
+        except (socket.error, OSError):
             pass
         self.handle = None
 
@@ -73,13 +73,13 @@ class TSocket(TSocketBase):
                 self.handle.settimeout(self._timeout)
                 try:
                     self.handle.connect(res[4])
-                except socket.error as e:
+                except (socket.error, OSError) as e:
                     if res is not res0[-1]:
                         continue
                     else:
                         raise e
                 break
-        except socket.error as e:
+        except (socket.error, OSError) as e:
             if self._unix_socket:
                 message = 'Could not connect to socket %s' % self._unix_socket
             else:
@@ -143,7 +143,7 @@ class TServerSocket(TSocketBase):
             tmp = socket.socket(res[0], res[1])
             try:
                 tmp.connect(res[4])
-            except socket.error as err:
+            except (socket.error, OSError) as err:
                 eno, message = err.args
                 if eno == errno.ECONNREFUSED:
                     os.unlink(res[4])


### PR DESCRIPTION
Since Python 3.3, socket.error has been merged into OSError.
https://docs.python.org/3/library/socket.html#socket.error
https://docs.python.org/3/library/exceptions.html#OSError

This is what happened before the fix:
```python
Exception in thread Thread-1:
Traceback (most recent call last):
  File "conda3/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "conda3/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)
  File "conda3/lib/python3.4/site-packages/thriftpy/server.py", line 98, in handle
    itrans.close()
  File "thriftpy/transport/buffered/cybuffered.pyx", line 38, in thriftpy.transport.buffered.cybuffered.TCyBufferedTransport.close (thriftpy/transport/buffered/cybuffered.c:1358)
  File "conda3/lib/python3.4/site-packages/thriftpy/transport/socket.py", line 29, in close
    self.handle.shutdown(socket.SHUT_RDWR)
OSError: [Errno 57] Socket is not connected
```