### PR TITLE
TClient: Add convenience method to close transports.

### DIFF
--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -194,6 +194,11 @@ class TClient(object):
         if hasattr(result, "success"):
             raise TApplicationException(TApplicationException.MISSING_RESULT)
 
+    def close(self):
+        self._iprot.trans.close()
+        if self._iprot != self._iprot:
+            self._oprot.trans.close()
+
 
 class TProcessor(object):
     """Base class for procsessor, which works on two streams."""


### PR DESCRIPTION
If the client is created via thriftpy.rpc.make_client, there seems to be
no public way of closing the connection to the server. This adds a
public method to TClient to do exactly that.

I know that for the PR to be accepted I still need to write a test :)
But I wanted to check first if you think this should indeed be merged. If you do, I'll prepare the test. 

This is just something I needed quickly for a project, and thought it might be useful to a wider audience.