### PR TITLE
Support integer boolean constants.

### DIFF
--- a/tests/parser-cases/constants.thrift
+++ b/tests/parser-cases/constants.thrift
@@ -1,3 +1,5 @@
+const bool tbool = true
+const bool tboolint = 1
 const i16 int16 = 3
 const i32 int32 = 800
 const i64 int64 = 123456789

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,6 +12,8 @@ def test_comments():
 
 def test_constants():
     thrift = load('parser-cases/constants.thrift')
+    assert thrift.tbool is True
+    assert thrift.tboolint is True
     assert thrift.int16 == 3
     assert thrift.int32 == 800
     assert thrift.int64 == 123456789

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -601,8 +601,8 @@ def _cast(t):  # noqa
 
 
 def _cast_bool(v):
-    assert isinstance(v, bool)
-    return v
+    assert isinstance(v, (bool, int))
+    return bool(v)
 
 
 def _cast_byte(v):


### PR DESCRIPTION
Some Thrift generators used to produce bad code for some languages that used
'true' and 'false' as reserved keywords, so there are Thrift files in the wild
that use {0,1} to represent the {false,true} boolean constant values.

This is also supported by Apache Thrift.