### PR TITLE
Simplify the read_i08() bool result cast.

### DIFF
--- a/thriftpy/protocol/cybin/cybin.pyx
+++ b/thriftpy/protocol/cybin/cybin.pyx
@@ -241,7 +241,7 @@ cdef c_read_val(CyTransportBase buf, TType ttype, spec=None):
     cdef TType v_type, k_type, orig_type, orig_key_type
 
     if ttype == T_BOOL:
-        return bool(read_i08(buf))
+        return <bint>read_i08(buf)
 
     elif ttype == T_I08:
         return read_i08(buf)


### PR DESCRIPTION
The cython-generated code for `bool(read_i08(buf))` includes a call to the
Python `bool` type function. That extra call is unnecessary in this case.
Instead, we can cast to cython's `bint` type, which generates code that
directly returns `Py_True` or `Py_False` (via `__Pyx_PyBool_FromLong`).

This appears to be the most efficient code generation for this expression.
For completeness, I also investigated these variants:

  - `<bool>read_i08(buf)`
  - `read_i08(buf) != 0`
  - `<bool>(read_i08(buf) != 0)`
  - `return False if read_i08(buf) == 0 else True`