### PR TITLE
init() now directly stores a copy of locals().

### DIFF
--- a/thriftpy/_compat.py
+++ b/thriftpy/_compat.py
@@ -81,9 +81,8 @@ def init_func_generator(spec):
     varnames = ('self', ) + varnames
 
     def init(self):
-        kwargs = locals()
-        kwargs.pop('self')
-        self.__dict__.update(kwargs)
+        self.__dict__ = locals().copy()
+        del self.__dict__['self']
 
     code = init.__code__
     if PY3:


### PR DESCRIPTION
We always start with an empty __dict__, and the dict.copy() method appears to
be a bit faster than dict.update().

Also, 'self' always exists in locals() so we can just delete that key directly
(instead of calling dict.pop()).