### PR TITLE
add unicode support for unicode_literals

### DIFF
--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -492,7 +492,7 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
         basename = os.path.basename(path)
         module_name = os.path.splitext(basename)[0]
 
-    thrift = types.ModuleType(module_name)
+    thrift = types.ModuleType(str(module_name))
     setattr(thrift, '__thrift_file__', path)
     thrift_stack.append(thrift)
     lexer.lineno = 1


### PR DESCRIPTION
when using unicode_literals from __future__, the module name will be in unicode, and due to module.__init__() argments must be string not unicode. So just cast the arg to string.