### PR TITLE
patch samefile method for windows user whos python version under 3.2

### DIFF
--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 
 import collections
 import os
+import sys
 import types
 from ply import lex, yacc
 from .lexer import *  # noqa
@@ -452,6 +453,8 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
                          cached, this is enabled by default. If `module_name`
                          is provided, use it as cache key, else use the `path`.
     """
+    if os.name == 'nt' and sys.version_info < (3, 2):
+        os.path.samefile = lambda f1, f2: os.stat(f1) == os.stat(f2)
 
     # dead include checking on current stack
     for thrift in thrift_stack:


### PR DESCRIPTION
ref #133 
https://github.com/python/cpython/blob/3.2/Lib/ntpath.py#L20
https://github.com/python/cpython/blob/3.1/Lib/ntpath.py#L19
As links shown above, we could found the samefile method was included since 3.2 on windows.


need to be tested