### PR TITLE
fix set_timeout backwards compatibility

### DIFF
--- a/thriftpy/transport/socket.py
+++ b/thriftpy/transport/socket.py
@@ -75,9 +75,8 @@ class TSocket(object):
         """Backward compat api, will bind the timeout to both connect_timeout
         and socket_timeout.
         """
-        if ms and ms > 0:
-            self.socket_timeout = ms / 1000
-            self.connect_timeout = self.socket_timeout
+        self.socket_timeout = ms / 1000 if (ms and ms > 0) else None
+        self.connect_timeout = self.socket_timeout
 
     def is_open(self):
         return bool(self.sock)


### PR DESCRIPTION
When given `None` as a timeout value, the `set_timeout` method would not actually set the timeouts to `None`.  This would leave the values at 3 s if the `TSocket` object was instantiated with default args.  This change ensures that calling `set_timeout(None)` really sets the timeouts to `None`.