### PR TITLE
Preserve traceback when re-raise undeclared exception

### DIFF
--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -251,7 +251,7 @@ class TProcessor(object):
                 setattr(result, exc_name, e)
                 break
         else:
-            raise e
+            raise
 
     def process(self, iprot, oprot):
         api, seqid, result, call = self.process_in(iprot)


### PR DESCRIPTION
This PR uses `raise` instead of `raise e` to re-raise exception in `thriftpy.thrift.TProcessor#handle_exception`, so the traceback of the original exception can be preserved.

**This PR will make something like this:**

```
ERROR:thriftpy.tornado:thrift exception in handle_stream
Traceback (most recent call last):
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/thriftpy/tornado.py", line 189, in handle_stream
    self._processor.handle_exception(e, result)
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/thriftpy/thrift.py", line 254, in handle_exception
    raise e
gaierror: [Errno -5] No address associated with hostname
```

**into this:**

```
ERROR:thriftpy.tornado:thrift exception in handle_stream
Traceback (most recent call last):
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/thriftpy/tornado.py", line 189, in handle_stream
    self._processor.handle_exception(e, result)
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/thriftpy/tornado.py", line 186, in handle_stream
    result.success = yield gen.maybe_future(call())
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/tornado/gen.py", line 1008, in run
    value = future.result()
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/tornado/concurrent.py", line 232, in result
    raise_exc_info(self._exc_info)
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/tornado/gen.py", line 1014, in run
    yielded = self.gen.throw(*exc_info)
  File "test.py", line 21, in ping
    yield self.make_a_request('http://something_goes_wrong')
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/tornado/gen.py", line 1008, in run
    value = future.result()
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/tornado/concurrent.py", line 232, in result
    raise_exc_info(self._exc_info)
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/tornado/gen.py", line 1014, in run
    yielded = self.gen.throw(*exc_info)
  File "test.py", line 15, in make_a_request
    response = yield self.http_client.fetch(url)
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/tornado/gen.py", line 1008, in run
    value = future.result()
  File "/home/.../thriftpy_exc/env/lib/python2.7/site-packages/tornado/concurrent.py", line 232, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
gaierror: [Errno -5] No address associated with hostname
```

Demo code:

```
import thriftpy
from thriftpy.tornado import make_client, make_server
from tornado import ioloop
from tornado import gen
from tornado import httpclient

pingpong = thriftpy.load("../thriftpy/examples/pingpong/pingpong.thrift")


class Dispatcher(object):
    http_client = httpclient.AsyncHTTPClient()

    @gen.coroutine
    def make_a_request(self, url):
        response = yield self.http_client.fetch(url)
        print 'Response got: ' + response.reason
        raise gen.Return(response)

    @gen.coroutine
    def ping(self):
        yield self.make_a_request('http://something_goes_wrong')
        raise gen.Return('pong')


server = make_server(pingpong.PingService, Dispatcher())
server.listen(6000)

client = ioloop.IOLoop.current().run_sync(
    lambda: make_client(pingpong.PingService, '127.0.0.1', 6000))
print ioloop.IOLoop.current().run_sync(client.ping)
```
