### PR TITLE
Drop to_bytes() in favor of inline UTF-8 encoding

### DIFF
--- a/thriftpy/transport/memory/cymemory.pyx
+++ b/thriftpy/transport/memory/cymemory.pyx
@@ -7,13 +7,6 @@ from thriftpy.transport.cybase cimport (
 )
 
 
-def to_bytes(s):
-    try:
-        return s.encode("utf-8")
-    except Exception:
-        return s
-
-
 cdef class TCyMemoryBuffer(CyTransportBase):
     cdef TCyBuffer buf
 
@@ -64,7 +57,8 @@ cdef class TCyMemoryBuffer(CyTransportBase):
         return self.get_string(sz)
 
     def write(self, data):
-        data = to_bytes(data)
+        if isinstance(data, unicode):
+            data = (<unicode>data).encode('utf-8')
 
         cdef int sz = len(data)
         return self.c_write(data, sz)
@@ -88,5 +82,6 @@ cdef class TCyMemoryBuffer(CyTransportBase):
         return self._getvalue()
 
     def setvalue(self, value):
-        value = to_bytes(value)
+        if isinstance(value, unicode):
+            value = (<unicode>value).encode('utf-8')
         self._setvalue(len(value), value)


### PR DESCRIPTION
We should only need to perform the UTF-8 encoding step when we are handed
a Unicode string, and performing the encoding inline lets Cython translate
this directly into a call to `PyUnicode_AsUTF8String()`.