### PR TITLE
Tell c_read_binary that it's decoding characters

### DIFF
--- a/thriftpy/protocol/cybin/cybin.pyx
+++ b/thriftpy/protocol/cybin/cybin.pyx
@@ -235,7 +235,7 @@ cdef inline c_read_binary(CyTransportBase buf, int32_t size):
 cdef inline c_read_string(CyTransportBase buf, int32_t size):
     py_data = c_read_binary(buf, size)
     try:
-        return py_data.decode("utf-8")
+        return (<char *>py_data)[:size].decode("utf-8")
     except:
         return py_data
 


### PR DESCRIPTION
These type and size hints let cython optimize the string decoding operation
to a pair of `__Pyx_PyObject_AsString` / `__Pyx_decode_c_string()` calls. This
is a lot more efficient than the previous code generation which invoked the
"encode" method on the abstract "py_data" object.

The performance improvement here varies based on how much string data exists
in the input buffer, but the benchmark suite shows a 40%+ speed improvement
with this change.