### PR TITLE
byte处理问题，include文件路径问题

### DIFF
--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -49,7 +49,7 @@ def p_include(p):
     if thrift.__thrift_file__ is None:
         raise ThriftParserError('Unexcepted include statement while loading'
                                 'from file like object.')
-    replace_include_dirs = [os.path.dirname(thrift.__thrift_file__)] 
+    replace_include_dirs = [os.path.dirname(thrift.__thrift_file__)] \
                             + include_dirs_
     for include_dir in replace_include_dirs:
         path = os.path.join(include_dir, p[2])

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -46,12 +46,12 @@ def p_header_unit(p):
 def p_include(p):
     '''include : INCLUDE LITERAL'''
     thrift = thrift_stack[-1]
-
     if thrift.__thrift_file__ is None:
         raise ThriftParserError('Unexcepted include statement while loading'
                                 'from file like object.')
-
-    for include_dir in include_dirs_:
+    replace_include_dirs = [os.path.dirname(thrift.__thrift_file__)] 
+                            + include_dirs_
+    for include_dir in replace_include_dirs:
         path = os.path.join(include_dir, p[2])
         if os.path.exists(path):
             child = parse(path)
@@ -153,7 +153,6 @@ def p_const_map_item(p):
 def p_const_ref(p):
     '''const_ref : IDENTIFIER'''
     child = thrift_stack[-1]
-
     for name in p[1].split('.'):
         father = child
         child = getattr(child, name, None)
@@ -609,7 +608,7 @@ def _cast_bool(v):
 
 
 def _cast_byte(v):
-    assert isinstance(v, str)
+    assert isinstance(v, int)
     return v
 
 


### PR DESCRIPTION
1、byte处理问题
thrift官网中说明，byte: An 8-bit signed integer。但是在parser.py文件的_cast_byte方法中却assert接收到的v为str类型。
2、include文件路径问题
这应该是一个建议，或者说值得改进的地方。
发现场景：thrift文件A中include了B文件，同时在B文件中include了C文件，B和C在同一个目录下，但同时和A不在同一目录下，这时如果只给了A的路径，则在解析B文件时对于include的C文件，就会报错，找不到C文件。
建议：parser.py文件中p_include方法，应该把当前解析的thrift文件所在路径加到include_dirs_中，而不是所有的thrift路径都需要调用parse方法时把所有thrift文件所在路径都添加进去，因为调用时用户并不一定知道其他文件include的文件都在哪些目录下。
