### PR TITLE
Assign generated init funcs unique names

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import linecache
+
 import pytest
 
 import thriftpy
@@ -68,3 +70,8 @@ def test_parse_spec():
 
     for spec, res in cases:
         assert parse_spec(*spec) == res
+
+
+def test_init_func():
+    thriftpy.load("addressbook.thrift")
+    assert linecache.getline('<generated PhoneNumber.__init__>', 1) != ''


### PR DESCRIPTION
Previously, all generated init funcs would receive the same name, which made
them impossible to differentiate in traces and profiling output. We now assign
each function a unique name based on its associated class.

Further, we can now add "fake" linecache entries for our generated functions
so that debuggers (like PDB) and the traceback module can better understand
the generated code.