### PR TITLE
fix for absolute paths on windows

### DIFF
--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -485,7 +485,7 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
         raise ThriftParserError('Path should end with .thrift')
 
     url_scheme = urlparse(path).scheme
-    if url_scheme == '':
+    if len(url_scheme) <= 1:
         with open(path) as fh:
             data = fh.read()
     elif url_scheme in ('http', 'https'):

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
 
 deps =
     pytest
-    tornado
+    tornado>=4.4,<4.5
     toro
     cython
     py26: ordereddict


### PR DESCRIPTION
An absolute path on windows looks like 'C:\foo\bar.thrift' and urlparse returns 'c' as the scheme which causes a parse error to be thrown when given an absolute path.  

```
>>> import thriftpy
>>> thriftpy.load('C:\\foo\\bar.thrift', 'Hbase_thrift')
Traceback (most recent call last):
  ...
  File "C:\Python27\lib\site-packages\thriftpy\parser\parser.py", line 501, in parse
    url_scheme))
ThriftParserError: ThriftPy does not support generating module with path in protocol 'c'
```

On Windows any letter 'a-zA-Z'  is a valid drive letter and empty string means the current drive and so we can handle this completely with the following test. 

```
if len(url_scheme) <= 1:

is roughly equivalent to, 

if url_scheme == '' or \
   url_scheme in tuple('abcdefghijklmnopqrstuvwxyz'):
```

In urlparse these are the valid scheme chars, 

```
'abcdefghijklmnopqrstuvwxyz'
'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
'0123456789'
'+-.'
```

If any other character appears, urlparse().scheme will return an empty string. A single digit number will never be returned in the scheme since urlparse handles this as a port number and would also return an empty string. Similarly urlparse always returns the lower case version of the scheme and so uppercase letters never appear. Lastly dot '.' is a valid scheme for example .\foo\bar.thrift 

This leaves only two characters '+-'

Its not really necessary to handle these two characters since the worst case is the user gets a detailed IOError Exception

```
>>> open('+:\\fakefile')
Traceback (most recent call last):
  File "<pyshell#11>", line 1, in <module>
    open('+:\\fakefile')
IOError: [Errno 2] No such file or directory: '+:\\fakefile'
>>>  

```

which makes more sense than the "ThriftParserError: ... protocol 'c' " exception and it stops it from failing for absolute paths on windows.

Please incorporate this fix in the next release of thriftypy. Thanks
