### PR TITLE
the problem of include thrift files with the same name in different path

### DIFF
--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -158,6 +158,7 @@ def p_const_ref(p):
     '''const_ref : IDENTIFIER'''
     child = thrift_stack[-1]
     for name in p[1].split('.'):
+
         father = child
         child_list = getattr(child, name, None)
         if child_list is None:
@@ -250,7 +251,6 @@ def p_service(p):
                | SERVICE IDENTIFIER EXTENDS IDENTIFIER '{' function_seq '}'
     '''
     thrift = thrift_stack[-1]
-
     if len(p) == 8:
         extends = thrift
         for name in p[4].split('.'):
@@ -262,11 +262,11 @@ def p_service(p):
                         break
             else:
                 extends = getattr(extends, name, None)
-
-            if extends is None:
-                raise ThriftParserError('Can\'t find service %r for '
-                                        'service %r to extend' %
-                                        (p[4], p[2]))
+                
+        if extends is None:
+            raise ThriftParserError('Can\'t find service %r for '
+                                    'service %r to extend' %
+                                    (p[4], p[2]))
 
         if not hasattr(extends, 'thrift_services'):
             raise ThriftParserError('Can\'t extends %r, not a service'
@@ -370,7 +370,6 @@ def p_field_type(p):
 def p_ref_type(p):
     '''ref_type : IDENTIFIER'''
     ref_type = thrift_stack[-1]
-
     for name in p[1].split('.'):
         if isinstance(ref_type, list):
             for r in ref_type:
@@ -381,9 +380,9 @@ def p_ref_type(p):
         else:
             ref_type = getattr(ref_type, name, None)
 
-    if ref_type is None:
-        raise ThriftParserError('No type found: %r, at line %d' %
-                                (p[1], p.lineno(1)))
+        if ref_type is None:
+            raise ThriftParserError('No type found: %r, at line %d' %
+                                    (p[1], p.lineno(1)))
 
 
     if hasattr(ref_type, '_ttype'):
@@ -392,7 +391,7 @@ def p_ref_type(p):
         p[0] = ref_type
 
 
-def p_base_type(p):  # noqa
+def p_base_type(p):  # noq
     '''base_type : BOOL
                  | BYTE
                  | I16

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -49,7 +49,7 @@ def p_include(p):
     if thrift.__thrift_file__ is None:
         raise ThriftParserError('Unexcepted include statement while loading'
                                 'from file like object.')
-    replace_include_dirs = [os.path.dirname(thrift.__thrift_file__)] 
+    replace_include_dirs = [os.path.dirname(thrift.__thrift_file__)] \
                             + include_dirs_
     for include_dir in replace_include_dirs:
         path = os.path.join(include_dir, p[2])

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -46,12 +46,12 @@ def p_header_unit(p):
 def p_include(p):
     '''include : INCLUDE LITERAL'''
     thrift = thrift_stack[-1]
-
     if thrift.__thrift_file__ is None:
         raise ThriftParserError('Unexcepted include statement while loading'
                                 'from file like object.')
-
-    for include_dir in include_dirs_:
+    replace_include_dirs = [os.path.dirname(thrift.__thrift_file__)] 
+                            + include_dirs_
+    for include_dir in replace_include_dirs:
         path = os.path.join(include_dir, p[2])
         if os.path.exists(path):
             child = parse(path)
@@ -153,7 +153,6 @@ def p_const_map_item(p):
 def p_const_ref(p):
     '''const_ref : IDENTIFIER'''
     child = thrift_stack[-1]
-
     for name in p[1].split('.'):
         father = child
         child = getattr(child, name, None)
@@ -609,7 +608,7 @@ def _cast_bool(v):
 
 
 def _cast_byte(v):
-    assert isinstance(v, str)
+    assert isinstance(v, int)
     return v
 
 

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -158,7 +158,6 @@ def p_const_ref(p):
     '''const_ref : IDENTIFIER'''
     child = thrift_stack[-1]
     for name in p[1].split('.'):
-
         father = child
         child_list = getattr(child, name, None)
         if child_list is None:
@@ -169,7 +168,7 @@ def p_const_ref(p):
         if _get_ttype(child) is None or _get_ttype(father) == TType.I32:
             # child is a constant or enum value
             p[0] = child
-            return
+            break
         else:
             raise ThriftParserError('No enum value or constant found '
                                     'named %r' % p[1])
@@ -262,11 +261,11 @@ def p_service(p):
                         break
             else:
                 extends = getattr(extends, name, None)
-                
-        if extends is None:
-            raise ThriftParserError('Can\'t find service %r for '
-                                    'service %r to extend' %
-                                    (p[4], p[2]))
+
+            if extends is None:
+                raise ThriftParserError('Can\'t find service %r for '
+                                        'service %r to extend' %
+                                        (p[4], p[2]))
 
         if not hasattr(extends, 'thrift_services'):
             raise ThriftParserError('Can\'t extends %r, not a service'
@@ -370,6 +369,7 @@ def p_field_type(p):
 def p_ref_type(p):
     '''ref_type : IDENTIFIER'''
     ref_type = thrift_stack[-1]
+
     for name in p[1].split('.'):
         if isinstance(ref_type, list):
             for r in ref_type:
@@ -380,9 +380,9 @@ def p_ref_type(p):
         else:
             ref_type = getattr(ref_type, name, None)
 
-        if ref_type is None:
-            raise ThriftParserError('No type found: %r, at line %d' %
-                                    (p[1], p.lineno(1)))
+    if ref_type is None:
+        raise ThriftParserError('No type found: %r, at line %d' %
+                                (p[1], p.lineno(1)))
 
 
     if hasattr(ref_type, '_ttype'):
@@ -391,7 +391,7 @@ def p_ref_type(p):
         p[0] = ref_type
 
 
-def p_base_type(p):  # noq
+def p_base_type(p):  # noqa
     '''base_type : BOOL
                  | BYTE
                  | I16
@@ -454,11 +454,9 @@ thrift_cache = {}
 def parse(path, module_name=None, include_dirs=None, include_dir=None,
           lexer=None, parser=None, enable_cache=True):
     """Parse a single thrift file to module object, e.g.::
-
         >>> from thriftpy.parser.parser import parse
         >>> note_thrift = parse("path/to/note.thrift")
         <module 'note_thrift' (built-in)>
-
     :param path: file path to parse, should be a string ending with '.thrift'.
     :param module_name: the name for parsed module, the default is the basename
                         without extension of `path`.
@@ -530,12 +528,10 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
 
 def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True):
     """Parse a file-like object to thrift module object, e.g.::
-
         >>> from thriftpy.parser.parser import parse_fp
         >>> with open("path/to/note.thrift") as fp:
                 parse_fp(fp, "note_thrift")
         <module 'note_thrift' (built-in)>
-
     :param source: file-like object, expected to have a method named `read`.
     :param module_name: the name for parsed module, shoule be endswith
                         '_thrift'.

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -158,7 +158,6 @@ def p_const_ref(p):
     '''const_ref : IDENTIFIER'''
     child = thrift_stack[-1]
     for name in p[1].split('.'):
-
         father = child
         child_list = getattr(child, name, None)
         if child_list is None:
@@ -169,7 +168,7 @@ def p_const_ref(p):
         if _get_ttype(child) is None or _get_ttype(father) == TType.I32:
             # child is a constant or enum value
             p[0] = child
-            return
+            break
         else:
             raise ThriftParserError('No enum value or constant found '
                                     'named %r' % p[1])
@@ -251,6 +250,7 @@ def p_service(p):
                | SERVICE IDENTIFIER EXTENDS IDENTIFIER '{' function_seq '}'
     '''
     thrift = thrift_stack[-1]
+
     if len(p) == 8:
         extends = thrift
         for name in p[4].split('.'):
@@ -262,11 +262,11 @@ def p_service(p):
                         break
             else:
                 extends = getattr(extends, name, None)
-                
-        if extends is None:
-            raise ThriftParserError('Can\'t find service %r for '
-                                    'service %r to extend' %
-                                    (p[4], p[2]))
+
+            if extends is None:
+                raise ThriftParserError('Can\'t find service %r for '
+                                        'service %r to extend' %
+                                        (p[4], p[2]))
 
         if not hasattr(extends, 'thrift_services'):
             raise ThriftParserError('Can\'t extends %r, not a service'
@@ -370,6 +370,7 @@ def p_field_type(p):
 def p_ref_type(p):
     '''ref_type : IDENTIFIER'''
     ref_type = thrift_stack[-1]
+
     for name in p[1].split('.'):
         if isinstance(ref_type, list):
             for r in ref_type:
@@ -380,9 +381,9 @@ def p_ref_type(p):
         else:
             ref_type = getattr(ref_type, name, None)
 
-        if ref_type is None:
-            raise ThriftParserError('No type found: %r, at line %d' %
-                                    (p[1], p.lineno(1)))
+    if ref_type is None:
+        raise ThriftParserError('No type found: %r, at line %d' %
+                                (p[1], p.lineno(1)))
 
 
     if hasattr(ref_type, '_ttype'):
@@ -391,7 +392,7 @@ def p_ref_type(p):
         p[0] = ref_type
 
 
-def p_base_type(p):  # noq
+def p_base_type(p):  # noqa
     '''base_type : BOOL
                  | BYTE
                  | I16
@@ -454,11 +455,9 @@ thrift_cache = {}
 def parse(path, module_name=None, include_dirs=None, include_dir=None,
           lexer=None, parser=None, enable_cache=True):
     """Parse a single thrift file to module object, e.g.::
-
         >>> from thriftpy.parser.parser import parse
         >>> note_thrift = parse("path/to/note.thrift")
         <module 'note_thrift' (built-in)>
-
     :param path: file path to parse, should be a string ending with '.thrift'.
     :param module_name: the name for parsed module, the default is the basename
                         without extension of `path`.
@@ -530,12 +529,10 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
 
 def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True):
     """Parse a file-like object to thrift module object, e.g.::
-
         >>> from thriftpy.parser.parser import parse_fp
         >>> with open("path/to/note.thrift") as fp:
                 parse_fp(fp, "note_thrift")
         <module 'note_thrift' (built-in)>
-
     :param source: file-like object, expected to have a method named `read`.
     :param module_name: the name for parsed module, shoule be endswith
                         '_thrift'.


### PR DESCRIPTION
在使用中发现，对于不同路径下同名文件的include，thriftpy模块使用了覆盖方式，即后include的文件覆盖了前面的同名文件。在此根据目前可以获取到的信息做了一个版本的修复，将同名文件放到一个list中。在使用时，对list进行遍历。
