### PR TITLE
Reset timeout after connection

### DIFF
--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -132,12 +132,22 @@ def test_client_socket_set_timeout():
 
     assert client_socket.sock.gettimeout() == 100 / 1000
     assert conn.sock.gettimeout() == 100 / 1000
-    assert conn.sock.gettimeout() == 100 / 1000
 
     client_socket.set_timeout(200)
     conn.set_timeout(200)
     assert client_socket.sock.gettimeout() == 200 / 1000
     assert conn.sock.gettimeout() == 200 / 1000
+
+    conn.close()
+    client_socket.close()
+
+    client_socket = TSocket(host="localhost", port=12345,
+                            socket_timeout=None, connect_timeout=100)
+    client_socket.open()
+
+    conn = server_socket.accept()
+
+    assert client_socket.sock.gettimeout() is None
 
     conn.close()
     client_socket.close()

--- a/thriftpy/transport/socket.py
+++ b/thriftpy/transport/socket.py
@@ -97,6 +97,9 @@ class TSocket(object):
 
             if self.socket_timeout:
                 self.sock.settimeout(self.socket_timeout)
+            elif self.connect_timeout:
+                # Reset timeout
+                self.sock.settimeout(None)
 
         except (socket.error, OSError):
             raise TTransportException(


### PR DESCRIPTION
If we set only `connect_timeout` — it will be used even after connection.
