### PR TITLE
Skip test_unix_domain_socket on darwin when non-root

### DIFF
--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division
 
 import os
 import socket
+import sys
 
 import pytest
 
@@ -47,6 +48,9 @@ def test_inet6_socket():
     _test_socket(server_socket, client_socket)
 
 
+@pytest.mark.skipif(
+    sys.platform == 'darwin' and os.getuid() != 0,
+    reason='os.mknod() requires super-user privileges on darwin')
 def test_unix_domain_socket():
     sock_file = "/tmp/thriftpy_test.sock"
 


### PR DESCRIPTION
Mknod() on Darwin (OX X / macOS) requires super-user privileges.

Otherwise, this test fails with:

```
OSError: [Errno 1] Operation not permitted
```
