### PR TITLE
Optionally use __slots__ for payload members

### DIFF
--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -82,38 +82,54 @@ def test_load_slots():
     )
 
     # normal structs will have slots
-    # assert set(thrift.PhoneNumber.__slots__) == set(['type', 'number', 'mix_item'])
-    # assert set(thrift.Person.__slots__) == set(['name', 'phones', 'created_at'])
-    # assert set(thrift.AddressBook.__slots__) == set(['people'])
-    # assert set(thrift.AddressBookService.__slots__) == set()
+    assert thrift.PhoneNumber.__slots__ == ['type', 'number', 'mix_item']
+    assert thrift.Person.__slots__ == ['name', 'phones', 'created_at']
+    assert thrift.AddressBook.__slots__ == ['people']
 
-    # one cannot get/set undefined attributes
-    # person = thrift.Person()
-    # with pytest.raises(AttributeError):
-    #     person.attr_not_exist = "Does not work"
+    # get/set undefined attributes
+    person = thrift.Person()
+    with pytest.raises(AttributeError):
+        person.attr_not_exist = "Does not work"
 
-    # with pytest.raises(AttributeError):
-    #     person.attr_not_exist
+    with pytest.raises(AttributeError):
+        person.attr_not_exist
 
-    # pn = thrift.PhoneNumber()
-    # with pytest.raises(AttributeError):
-    #     pn.attr_not_exist = "Does not work"
+    pn = thrift.PhoneNumber()
+    with pytest.raises(AttributeError):
+        pn.attr_not_exist = "Does not work"
 
-    # with pytest.raises(AttributeError):
-    #     pn.attr_not_exist
+    with pytest.raises(AttributeError):
+        pn.attr_not_exist
 
-    # ab = thrift.AddressBook()
-    # with pytest.raises(AttributeError):
-    #     ab.attr_not_exist = "Does not work"
+    ab = thrift.AddressBook()
+    with pytest.raises(AttributeError):
+        ab.attr_not_exist = "Does not work"
 
-    # with pytest.raises(AttributeError):
-    #     ab.attr_not_exist
+    with pytest.raises(AttributeError):
+        ab.attr_not_exist
+    # eo: get/set
 
     # exceptions will not have slots
-    # assert not hasattr(thrift.PersonNotExistsError, '__slots__')
+    assert not hasattr(thrift.PersonNotExistsError, '__slots__')
 
     # enums will not have slots
-    # assert not hasattr(thrift.PhoneType, '__slots__')
+    assert not hasattr(thrift.PhoneType, '__slots__')
+
+    # service itself will not be created with slots
+    assert not hasattr(thrift.AddressBookService, '__slots__')
+
+    # service args will have slots
+    args_slots = thrift.AddressBookService.get_phonenumbers_args.__slots__
+    assert args_slots == ['name', 'count']
+
+    # XXX: service result will have their slot list empty until after they are
+    # created. This is because the success field is inserted after calling
+    # _make_struct. We could hardcode a check in the metaclass for names ending
+    # with _result, but I'm unsure if its a good idea. This should usually not
+    # be an issue since this object is only used internally, but we can revisit
+    # the need to have it available when required.
+    result_obj = thrift.AddressBookService.get_phonenumbers_result()
+    assert result_obj.__slots__ == ['success']
 
     # should be able to pickle slotted objects - if load with module_name
     bob = thrift.Person(name="Bob")

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -130,3 +130,10 @@ def test_load_slots():
     p_str = pickle.dumps(bob)
 
     assert pickle.loads(p_str) == bob
+
+    # works for recursive types too
+    rec = thriftpy.load('parser-cases/recursive_union.thrift', use_slots=True)
+    rec_slots = rec.Dynamic.__slots__
+    assert rec_slots == ['boolean', 'integer', 'doubl', 'str', 'arr', 'object']
+    with pytest.raises(AttributeError):
+        rec.Dynamic.attr_not_exist = "shouldn't work"

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -135,5 +135,6 @@ def test_load_slots():
     rec = thriftpy.load('parser-cases/recursive_union.thrift', use_slots=True)
     rec_slots = rec.Dynamic.__slots__
     assert rec_slots == ['boolean', 'integer', 'doubl', 'str', 'arr', 'object']
+    dyn = rec.Dynamic()
     with pytest.raises(AttributeError):
-        rec.Dynamic.attr_not_exist = "shouldn't work"
+        dyn.attr_not_exist = "shouldn't work"

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -122,14 +122,8 @@ def test_load_slots():
     args_slots = thrift.AddressBookService.get_phonenumbers_args.__slots__
     assert args_slots == ['name', 'count']
 
-    # XXX: service result will have their slot list empty until after they are
-    # created. This is because the success field is inserted after calling
-    # _make_struct. We could hardcode a check in the metaclass for names ending
-    # with _result, but I'm unsure if its a good idea. This should usually not
-    # be an issue since this object is only used internally, but we can revisit
-    # the need to have it available when required.
-    result_obj = thrift.AddressBookService.get_phonenumbers_result()
-    assert result_obj.__slots__ == ['success']
+    result_slots = thrift.AddressBookService.get_phonenumbers_result.__slots__
+    assert result_slots == ['success']
 
     # should be able to pickle slotted objects - if load with module_name
     bob = thrift.Person(name="Bob")

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -82,26 +82,38 @@ def test_load_slots():
     )
 
     # normal structs will have slots
-    assert thrift.PhoneNumber.__slots__ == ['type', 'number', 'mix_item']
-    assert thrift.Person.__slots__ == ['name', 'phones', 'created_at']
-    assert thrift.AddressBook.__slots__ == ['people']
-
-    # XXX: should unions have slots?
-
-    # exceptions will not have slots
-    assert not hasattr(thrift.PersonNotExistsError, '__slots__')
-
-    # services will not have slots
-    assert not hasattr(thrift.AddressBookService, '__slots__')
-
-    # enums will not have slots
-    assert not hasattr(thrift.PhoneType, '__slots__')
+    # assert set(thrift.PhoneNumber.__slots__) == set(['type', 'number', 'mix_item'])
+    # assert set(thrift.Person.__slots__) == set(['name', 'phones', 'created_at'])
+    # assert set(thrift.AddressBook.__slots__) == set(['people'])
+    # assert set(thrift.AddressBookService.__slots__) == set()
 
     # one cannot get/set undefined attributes
-    person = thrift.Person()
-    with pytest.raises(AttributeError):
-        person.attr_not_exist = "Does not work"
-        person.attr_not_exist
+    # person = thrift.Person()
+    # with pytest.raises(AttributeError):
+    #     person.attr_not_exist = "Does not work"
+
+    # with pytest.raises(AttributeError):
+    #     person.attr_not_exist
+
+    # pn = thrift.PhoneNumber()
+    # with pytest.raises(AttributeError):
+    #     pn.attr_not_exist = "Does not work"
+
+    # with pytest.raises(AttributeError):
+    #     pn.attr_not_exist
+
+    # ab = thrift.AddressBook()
+    # with pytest.raises(AttributeError):
+    #     ab.attr_not_exist = "Does not work"
+
+    # with pytest.raises(AttributeError):
+    #     ab.attr_not_exist
+
+    # exceptions will not have slots
+    # assert not hasattr(thrift.PersonNotExistsError, '__slots__')
+
+    # enums will not have slots
+    # assert not hasattr(thrift.PhoneType, '__slots__')
 
     # should be able to pickle slotted objects - if load with module_name
     bob = thrift.Person(name="Bob")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -260,3 +260,27 @@ def test_issue_215():
     thrift = load('parser-cases/issue_215.thrift')
     assert thrift.abool is True
     assert thrift.falseValue == 123
+
+
+def test_load_slots():
+    thrift = load('addressbook.thrift', use_slots=True)
+
+    # normal structs will have slots
+    assert thrift.PhoneNumber.__slots__ == ['type', 'number', 'mix_item']
+    assert thrift.Person.__slots__ == ['name', 'phones', 'created_at']
+    assert thrift.AddressBook.__slots__ == ['people']
+
+    # exceptions will not have slots
+    assert not hasattr(thrift.PersonNotExistsError, '__slots__')
+
+    # services will not have slots
+    assert not hasattr(thrift.AddressBookService, '__slots__')
+
+    # enums will not have slots
+    assert not hasattr(thrift.PhoneType, '__slots__')
+
+    # one cannot get/set undefined attributes
+    person = thrift.Person()
+    with pytest.raises(AttributeError):
+        person.attr_not_exist = "Does not work"
+        person.attr_not_exist

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,6 @@
 import pytest
 from thriftpy.thrift import TType
 from thriftpy.parser import load, load_fp
-from thriftpy.parser.parser import thrift_cache
 from thriftpy.parser.exc import ThriftParserError, ThriftGrammerError
 
 
@@ -264,7 +263,6 @@ def test_issue_215():
 
 
 def test_load_slots():
-    thrift_cache.clear()
     thrift = load('addressbook.thrift', use_slots=True)
 
     # normal structs will have slots

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,6 +3,7 @@
 import pytest
 from thriftpy.thrift import TType
 from thriftpy.parser import load, load_fp
+from thriftpy.parser.parser import thrift_cache
 from thriftpy.parser.exc import ThriftParserError, ThriftGrammerError
 
 
@@ -263,6 +264,7 @@ def test_issue_215():
 
 
 def test_load_slots():
+    thrift_cache.clear()
     thrift = load('addressbook.thrift', use_slots=True)
 
     # normal structs will have slots

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -260,27 +260,3 @@ def test_issue_215():
     thrift = load('parser-cases/issue_215.thrift')
     assert thrift.abool is True
     assert thrift.falseValue == 123
-
-
-def test_load_slots():
-    thrift = load('addressbook.thrift', use_slots=True)
-
-    # normal structs will have slots
-    assert thrift.PhoneNumber.__slots__ == ['type', 'number', 'mix_item']
-    assert thrift.Person.__slots__ == ['name', 'phones', 'created_at']
-    assert thrift.AddressBook.__slots__ == ['people']
-
-    # exceptions will not have slots
-    assert not hasattr(thrift.PersonNotExistsError, '__slots__')
-
-    # services will not have slots
-    assert not hasattr(thrift.AddressBookService, '__slots__')
-
-    # enums will not have slots
-    assert not hasattr(thrift.PhoneType, '__slots__')
-
-    # one cannot get/set undefined attributes
-    person = thrift.Person()
-    with pytest.raises(AttributeError):
-        person.attr_not_exist = "Does not work"
-        person.attr_not_exist

--- a/thriftpy/parser/__init__.py
+++ b/thriftpy/parser/__init__.py
@@ -15,7 +15,7 @@ import sys
 from .parser import parse, parse_fp
 
 
-def load(path, module_name=None, include_dirs=None, include_dir=None):
+def load(path, module_name=None, include_dirs=None, include_dir=None, use_slots=False):
     """Load thrift file as a module.
 
     The module loaded and objects inside may only be pickled if module_name
@@ -27,17 +27,17 @@ def load(path, module_name=None, include_dirs=None, include_dir=None):
     """
     real_module = bool(module_name)
     thrift = parse(path, module_name, include_dirs=include_dirs,
-                   include_dir=include_dir)
+                   include_dir=include_dir, use_slots=use_slots)
 
     if real_module:
         sys.modules[module_name] = thrift
     return thrift
 
 
-def load_fp(source, module_name):
+def load_fp(source, module_name, use_slots=False):
     """Load thrift file like object as a module.
     """
-    thrift = parse_fp(source, module_name)
+    thrift = parse_fp(source, module_name, use_slots=use_slots)
     sys.modules[module_name] = thrift
     return thrift
 

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -833,6 +833,8 @@ def _make_service(name, funcs, extends, use_slots=False):
             result_cls.default_spec.insert(0, ('success', None))
         gen_init(result_cls, result_cls.thrift_spec, result_cls.default_spec)
         setattr(cls, result_name, result_cls)
+        # default spec is modified after making struct so add slots here
+        result_cls.__slots__ = [f for f, _ in result_cls.default_spec]
         thrift_services.append(func_name)
     if extends is not None and hasattr(extends, 'thrift_services'):
         thrift_services.extend(extends.thrift_services)

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -436,6 +436,10 @@ include_dirs_ = ['.']
 thrift_cache = {}
 
 
+def _get_cache_key(prefix, use_slots=False):
+    return ('%s:slotted' % prefix) if use_slots else prefix
+
+
 def parse(path, module_name=None, include_dirs=None, include_dir=None,
           lexer=None, parser=None, enable_cache=True, use_slots=False):
     """Parse a single thrift file to module object, e.g.::
@@ -471,7 +475,8 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
 
     global thrift_cache
 
-    cache_key = module_name or os.path.normpath(path)
+    cache_prefix = module_name or os.path.normpath(path)
+    cache_key = _get_cache_key(cache_prefix, use_slots)
 
     if enable_cache and cache_key in thrift_cache:
         return thrift_cache[cache_key]
@@ -545,8 +550,10 @@ def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True, us
         raise ThriftParserError('ThriftPy can only generate module with '
                                 '\'_thrift\' suffix')
 
+    cache_key = _get_cache_key(module_name, use_slots)
+
     if enable_cache and module_name in thrift_cache:
-        return thrift_cache[module_name]
+        return thrift_cache[cache_key]
 
     if not hasattr(source, 'read'):
         raise ThriftParserError('Except `source` to be a file-like object with'
@@ -569,7 +576,7 @@ def parse_fp(source, module_name, lexer=None, parser=None, enable_cache=True, us
     thrift_stack.pop()
 
     if enable_cache:
-        thrift_cache[module_name] = thrift
+        thrift_cache[cache_key] = thrift
     return thrift
 
 

--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -128,11 +128,65 @@ class TMessageType(object):
 
 class TPayloadMeta(type):
 
+    _class_cache = {}
+
     def __new__(cls, name, bases, attrs):
         if "default_spec" in attrs:
             spec = attrs.pop("default_spec")
             attrs["__init__"] = init_func_generator(cls, spec)
         return super(TPayloadMeta, cls).__new__(cls, name, bases, attrs)
+
+# checks: instance and subclass checks
+    def __instancecheck__(cls, inst):
+        mod = inst.__class__.__module__
+        name = inst.__class__.__name__
+        key = "%s:%s" % (mod, name)
+        repl_cls = TPayloadMeta._class_cache.get(key)
+        if repl_cls is None:
+            return type.__instancecheck__(cls, inst)
+        return inst.__class__ is repl_cls
+
+    def __subclasscheck__(cls, subcls):
+        mod = cls.__module__
+        name = cls.__name__
+        key = "%s:%s" % (mod, name)
+        repl_cls = TPayloadMeta._class_cache.get(key)
+        if repl_cls is None:
+            return type.__subclasscheck__(cls, subcls)
+        if cls == repl_cls:
+            return True
+        # the first class in __mro__ is replaced by the replacement class so we
+        # can only look up from the second position
+        return cls.__mro__[1] in repl_cls.__mro__
+# eo: checks
+
+    def __call__(cls, *args, **kw):
+        if not cls.__mro__[1] == TSPayload:
+            return super(TPayloadMeta, cls).__call__(cls, *args, **kw)
+        # XXX: replaces class with new class using slot list from default_spec
+        cls_name = cls.__name__.split('.')[-1]
+        cache_key = '%s:%s' % (cls.__module__, cls_name)
+        # XXX: we trust default_spec more than __slots__ for this
+        fields = tuple(field for field, _ in cls.default_spec)
+        cls_obj = TPayloadMeta._class_cache.get(cache_key)
+        if not cls_obj:
+            cls_obj = type(
+                cls_name,
+                cls.__mro__,
+                {
+                    '__slots__': fields,
+                    '__module__': cls.__module__,
+                }
+            )
+            # XXX: need a better way to do this; its a dupe from parser.py
+            cls_obj._ttype = cls._ttype
+            cls_obj._tspec = cls._tspec
+            cls_obj.default_spec = cls.default_spec
+            cls_obj.thrift_spec = cls.thrift_spec
+            # cls.__init__ is already bound to cls
+            cls_obj.__init__ = init_func_generator(cls_obj, cls.default_spec)
+            TPayloadMeta._class_cache[cache_key] = cls_obj
+        return type.__call__(cls_obj, *args, **kw)
 
 
 def gen_init(cls, thrift_spec=None, default_spec=None):
@@ -169,12 +223,11 @@ class TPayload(with_metaclass(TPayloadMeta, object)):
         return not self.__eq__(other)
 
 
-# XXX: Move payload methods into separate sharable location
 class TSPayload(with_metaclass(TPayloadMeta, object)):
 
-    __hash__ = None
-
     __slots__ = tuple()
+
+    __hash__ = None
 
     def read(self, iprot):
         iprot.read_struct(self)

--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -140,7 +140,6 @@ class TPayloadMeta(type):
         return super(TPayloadMeta, cls).__new__(cls, name, bases, attrs)
 
     def __call__(cls, *args, **kw):
-        # if issubclass(cls, TSPayload):
         if not issubclass(cls, TSPayload):
             return type.__call__(cls, *args, **kw)
         cls_name = cls.__name__.split('.')[-1]

--- a/thriftpy/thrift.py
+++ b/thriftpy/thrift.py
@@ -220,9 +220,9 @@ class TSPayload(with_metaclass(TPayloadMeta, object)):
         if not isinstance(other, self.__class__):
             return False
         keys = self.__slots__
-        vals1 = [getattr(self, k) for k in keys]
-        vals2 = [getattr(self, k) for k in keys]
-        return vals1 == vals2
+        this = [getattr(self, k) for k in keys]
+        other_ = [getattr(other, k) for k in keys]
+        return this == other_
 
     def __ne__(self, other):
         return not self.__eq__(other)


### PR DESCRIPTION
Fixes #198

- Add TSPayload for slot based structs
- Add new optional use_slots parameter to allow generating code with slots
- Cache slot based objects slightly differently to avoid cache poisoning
