### PR TITLE
Fix double typed int values cannot be cast closes #242

### DIFF
--- a/tests/parser-cases/double_type_int.thrift
+++ b/tests/parser-cases/double_type_int.thrift
@@ -1,0 +1,7 @@
+struct Book {
+    1: string name,
+    2: double price = 1,
+}
+
+const double value1 = 3;
+const double value2 = 3.1;

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -262,6 +262,15 @@ def test_issue_215():
     assert thrift.falseValue == 123
 
 
+def test_issue_242():
+    thrift = load('parser-cases/double_type_int.thrift')
+    book = thrift.Book()
+    assert book.price == 1
+    assert isinstance(book.price, float)
+    assert isinstance(thrift.value1, float) and thrift.value1 == 3
+    assert isinstance(thrift.value2, float) and thrift.value2 == 3.1
+
+
 def test_annotations():
     load('parser-cases/annotations.thrift')
     load('parser-cases/issue_252.thrift')

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -688,8 +688,8 @@ def _cast_i64(v):
 
 
 def _cast_double(v):
-    assert isinstance(v, float)
-    return v
+    assert isinstance(v, (float, int))
+    return float(v)
 
 
 def _cast_string(v):


### PR DESCRIPTION
1. Now double typed integer value definitions like `double v = 1` can pass the parser.