### PR TITLE
Add support for i8 (alias to byte)

### DIFF
--- a/tests/const.thrift
+++ b/tests/const.thrift
@@ -1,6 +1,7 @@
 const i16 NEGATIVE_I16 = -10
 const double NEGATIVE_DOUBLE = -123.456
 
+const i8 I8_CONST = 10
 const i16 I16_CONST = 10
 const i32 I32_CONST = 100000
 const double DOUBLE_CONST = 123.456

--- a/thriftpy/parser/lexer.py
+++ b/thriftpy/parser/lexer.py
@@ -122,6 +122,7 @@ keywords = (
     'void',
     'bool',
     'byte',
+    'i8',
     'i16',
     'i32',
     'i64',

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -389,6 +389,7 @@ def p_ref_type(p):
 def p_simple_base_type(p):  # noqa
     '''simple_base_type : BOOL
                         | BYTE
+                        | I8
                         | I16
                         | I32
                         | I64
@@ -398,6 +399,8 @@ def p_simple_base_type(p):  # noqa
     if p[1] == 'bool':
         p[0] = TType.BOOL
     if p[1] == 'byte':
+        p[0] = TType.BYTE
+    if p[1] == 'i8':
         p[0] = TType.BYTE
     if p[1] == 'i16':
         p[0] = TType.I16


### PR DESCRIPTION
Apache Thrift has deprecated the `byte` type in favor of `i8` in recent versions, this patch makes thriftpy support both.
