### PR TITLE
Reset self.sock if connection fails

### DIFF
--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -149,7 +149,7 @@ def test_client_socket_set_timeout():
 
 
 def test_client_socket_not_open_after_failed_open():
-    client_socket = TSocket(host="localhost", port=12345, socket_timeout=100)
+    client_socket = TSocket(host="localhost", port=12345)
     assert not client_socket.is_open()
 
     with pytest.raises(TTransportException):
@@ -159,7 +159,7 @@ def test_client_socket_not_open_after_failed_open():
 
 
 def test_client_socket_not_open_after_close():
-    client_socket = TSocket(host="localhost", port=12345, socket_timeout=100)
+    client_socket = TSocket(host="localhost", port=12345)
     assert not client_socket.is_open()
 
     with pytest.raises(TTransportException):

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -146,3 +146,24 @@ def test_client_socket_set_timeout():
     conn.close()
     client_socket.close()
     server_socket.close()
+
+
+def test_client_socket_not_open_after_failed_open():
+    client_socket = TSocket(host="localhost", port=12345, socket_timeout=100)
+    assert not client_socket.is_open()
+
+    with pytest.raises(TTransportException):
+        client_socket.open()
+
+    assert not client_socket.is_open()
+
+
+def test_client_socket_not_open_after_close():
+    client_socket = TSocket(host="localhost", port=12345, socket_timeout=100)
+    assert not client_socket.is_open()
+
+    with pytest.raises(TTransportException):
+        client_socket.open()
+    client_socket.close()
+
+    assert not client_socket.is_open()

--- a/thriftpy/transport/socket.py
+++ b/thriftpy/transport/socket.py
@@ -99,6 +99,7 @@ class TSocket(object):
                 self.sock.settimeout(self.socket_timeout)
 
         except (socket.error, OSError):
+            self.sock = None
             raise TTransportException(
                 type=TTransportException.NOT_OPEN,
                 message="Could not connect to %s" % str(addr))

--- a/thriftpy/transport/socket.py
+++ b/thriftpy/transport/socket.py
@@ -141,7 +141,7 @@ class TSocket(object):
             self.sock.close()
             self.sock = None
         except (socket.error, OSError):
-            pass
+            self.sock = None
 
 
 class TServerSocket(object):


### PR DESCRIPTION
If we don't reset `self.sock` on connection error, then `my_socket.is_open()` will still return `True` after `TTransportException` is thrown. This may lead consumers to believe the `TSocket` can still be used. Example:

```python
>>> from thriftpy.transport import TSocket
>>> t = TSocket(host='google.com', port=7777)
>>> t.is_open()
False
>>> t.open()
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/thriftpy/transport/socket.py", line 96, in open
    self.sock.connect(addr)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/thriftpy/transport/socket.py", line 104, in open
    message="Could not connect to %s" % str(addr))
thriftpy.transport.TTransportException: TTransportException(type=1, message="Could not connect to ('google.com', 7777)")
>>> t.is_open()
True
```

The code that lead to this was more complicated, of course, but the point is that without this patch, consumers need to be very careful with error handling.