### PR TITLE
Recognize the `cpp_include` header keyword

### DIFF
--- a/tests/parser-cases/cpp_include.thrift
+++ b/tests/parser-cases/cpp_include.thrift
@@ -1,0 +1,1 @@
+cpp_include "<unordered_map>"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,6 +35,10 @@ def test_include():
     assert thrift.datetime == 1422009523
 
 
+def test_cpp_include():
+    load('parser-cases/cpp_include.thrift')
+
+
 def test_tutorial():
     thrift = load('parser-cases/tutorial.thrift', include_dirs=[
         './parser-cases'])

--- a/thriftpy/parser/lexer.py
+++ b/thriftpy/parser/lexer.py
@@ -119,6 +119,7 @@ thrift_reserved_keywords = (
 keywords = (
     'namespace',
     'include',
+    'cpp_include',
     'void',
     'bool',
     'byte',

--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -41,6 +41,7 @@ def p_header_unit_(p):
 
 def p_header_unit(p):
     '''header_unit : include
+                   | cpp_include
                    | namespace'''
 
 
@@ -61,6 +62,10 @@ def p_include(p):
             return
     raise ThriftParserError(('Couldn\'t include thrift %s in any '
                              'directories provided') % p[2])
+
+
+def p_cpp_include(p):
+    '''cpp_include : CPP_INCLUDE LITERAL'''
 
 
 def p_namespace(p):


### PR DESCRIPTION
`cpp_include` adds a custom C++ include to the output of the C++ code
generator for this Thrift document. While (obviously) not used by the
Python implementation, it can still appear in Thrift IDL files that we
need to parse, so we recognize the keyword and just discard the value.

See also: https://thrift.apache.org/docs/idl#c-include

Fixes #297 