### PR TITLE
Improve the DUBCONSTANT regular expression

### DIFF
--- a/tests/parser-cases/doubles.thrift
+++ b/tests/parser-cases/doubles.thrift
@@ -5,3 +5,6 @@ struct Book {
 
 const double value1 = 3;
 const double value2 = 3.1;
+const double value3 = 1e5;
+const double value4 = -1.5e-5
+const double value5 = +1.5E+5

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -262,13 +262,16 @@ def test_issue_215():
     assert thrift.falseValue == 123
 
 
-def test_issue_242():
-    thrift = load('parser-cases/double_type_int.thrift')
+def test_doubles():
+    thrift = load('parser-cases/doubles.thrift')
     book = thrift.Book()
     assert book.price == 1
     assert isinstance(book.price, float)
     assert isinstance(thrift.value1, float) and thrift.value1 == 3
     assert isinstance(thrift.value2, float) and thrift.value2 == 3.1
+    assert isinstance(thrift.value3, float) and thrift.value3 == 100000.0
+    assert isinstance(thrift.value4, float) and thrift.value4 == -1.5e-05
+    assert isinstance(thrift.value5, float) and thrift.value5 == 150000.0
 
 
 def test_annotations():

--- a/thriftpy/parser/lexer.py
+++ b/thriftpy/parser/lexer.py
@@ -198,7 +198,7 @@ def t_BOOLCONSTANT(t):
 
 
 def t_DUBCONSTANT(t):
-    r'-?\d+\.\d*(e-?\d+)?'
+    r'[+-]?\d+(?=\.|[Ee])(\.\d*)?([Ee][+-]?\d+)?'
     t.value = float(t.value)
     return t
 


### PR DESCRIPTION
The previous regular expression for parsing DUBCONSTANT (double
constant) values didn't handle a few cases that are supported by the
Thrift IDL specification.

 - `1e5` - extended notation without a decimal component
 - `+1.5E+5` - explicit `+` signs and capital `E` character