### PR TITLE
Support implicit field keys

### DIFF
--- a/tests/parser-cases/implicit_field_keys.thrift
+++ b/tests/parser-cases/implicit_field_keys.thrift
@@ -1,0 +1,9 @@
+exception NetworkError {
+    string message,
+    i32 http_code,
+}
+
+service Service {
+    bool send(i64 id, string message)
+        throws (NetworkError network_error)
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -281,3 +281,26 @@ def test_doubles():
 def test_annotations():
     load('parser-cases/annotations.thrift')
     load('parser-cases/issue_252.thrift')
+
+
+def test_implicit_field_keys():
+    thrift = load('parser-cases/implicit_field_keys.thrift')
+    assert thrift.NetworkError.thrift_spec == {
+        -1: (TType.STRING, 'message', False),
+        -2: (TType.I32, 'http_code', False),
+    }
+    assert thrift.Service.thrift_services == ['send']
+    assert thrift.Service.send_args.thrift_spec == {
+        -1: (TType.I64, 'id', False),
+        -2: (TType.STRING, 'message', False),
+    }
+    assert thrift.Service.send_args.default_spec == [
+        ('id', None), ('message', None)
+    ]
+    assert thrift.Service.send_result.thrift_spec == {
+        0: (TType.BOOL, 'success', False),
+        -1: (TType.STRUCT, 'network_error', thrift.NetworkError, False)
+    }
+    assert thrift.Service.send_result.default_spec == [
+        ('success', None), ('network_error', None)
+    ]


### PR DESCRIPTION
Fields without explicit keys are automatically assigned starting from -1
and working their way down. Implicit field keys are deprecated by Apache
Thrift, but supporting them gives us greater Thrift IDL compatibility.