### PR TITLE
Matching of absolute path in Windows

### DIFF
--- a/thriftpy/parser/parser.py
+++ b/thriftpy/parser/parser.py
@@ -544,7 +544,7 @@ def parse(path, module_name=None, include_dirs=None, include_dir=None,
     if url_scheme == 'file':
         with open(urlparse(path).netloc + urlparse(path).path) as fh:
             data = fh.read()
-    elif url_scheme == '':
+    elif len(url_scheme) <= 1:
         with open(path) as fh:
             data = fh.read()
     elif url_scheme in ('http', 'https'):


### PR DESCRIPTION
When we use thriftpy.load(path, ....) function. if the path is absulute path, after urlparse, the scheme is 'c'/'d'/'e', and the judgment here will not be matched. So this change can make the module more friendly to Windows.